### PR TITLE
Add linting pre-commit script

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,18 @@ Taskter now supports LLM-based agents that can be assigned to tasks. These agent
 When a task is executed, the agent will attempt to perform the task. If successful, the task is marked as "Done". If it fails, the task is moved back to "To Do", unassigned, and a comment from the agent is added.
 
 In the interactive board (`taskter board`), tasks assigned to an agent will be marked with a `*`. You can view the assigned agent ID and any comments by selecting the task and pressing `Enter`.
+
+## Development
+
+Run the included helper script before committing changes to ensure the code is
+formatted, linted and all tests pass:
+
+```bash
+./scripts/precommit.sh
+```
+
+If you want Git to run it automatically, create a pre-commit hook:
+
+```bash
+ln -s ../../scripts/precommit.sh .git/hooks/pre-commit
+```

--- a/scripts/precommit.sh
+++ b/scripts/precommit.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Format code
+cargo fmt --all -- --check || exit 1
+
+# Lint code with clippy
+cargo clippy --all-targets --all-features -- -D warnings || exit 1
+
+# Run tests
+cargo test || exit 1
+
+exit 0


### PR DESCRIPTION
## Summary
- add `scripts/precommit.sh` with `cargo fmt`, `cargo clippy` and tests
- document how to run the script in README

## Testing
- `./scripts/precommit.sh` *(fails: 'cargo-fmt' not installed)*
- `cargo test --quiet` *(fails: could not fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_6875a2b10f9c8320b724d63fb0188b73