### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM rust:1.88.0 as builder
+WORKDIR /usr/src/taskter
+COPY . .
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/src/taskter/target/release/taskter /usr/local/bin/taskter
+WORKDIR /workspace
+ENTRYPOINT ["taskter"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,25 @@ cargo install --path .
 ```
 This will install the `taskter` executable in your Cargo bin directory (usually `~/.cargo/bin/`), which should be in your `PATH`.
 
+## Docker
+
+You can build and run Taskter without installing Rust locally by using Docker.
+The included `Dockerfile` uses the official `rust:1.88.0` image to build the
+application.
+
+Build the container image:
+
+```bash
+docker build -t taskter .
+```
+
+Start the application with Docker Compose. If you use the Gemini integration,
+pass your API key as an environment variable:
+
+```bash
+GEMINI_API_KEY=<your_key> docker compose run --rm taskter --help
+```
+
 
 ## Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.8"
+services:
+  taskter:
+    build: .
+    working_dir: /workspace
+    volumes:
+      - .:/workspace
+    environment:
+      - GEMINI_API_KEY=${GEMINI_API_KEY}


### PR DESCRIPTION
## Summary
- add Dockerfile for building and running the CLI
- add docker-compose.yml convenience file
- document Docker usage in README
- update Dockerfile to use stable Rust 1.88.0
- document how to pass `GEMINI_API_KEY` when running with Docker Compose

## Testing
- `cargo test --locked --offline` *(fails: no matching package named `clap` found)*
- `cargo test --locked` *(fails: failed to fetch crates, network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6875a19039d483208c8879f370209ed4