### PR TITLE
Add CI workflow for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Run tests
+        run: cargo test --all --verbose


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run `cargo test` on pull requests targeting `main`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6875b153dbf483208a570eabc6b56506