### PR TITLE
Add pre-alpha warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Taskter is a terminal Kanban board CLI tool built with Rust.
 
+> **Warning**
+> This project is currently in a *pre-alpha* state and is actively maintained. Expect breaking changes and incomplete features.
+
 ## Features
 
 - Kanban board with tasks (ToDo, InProgress, Done)


### PR DESCRIPTION
## Summary
- warn that the project is currently pre-alpha but actively maintained

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: explicit closure for copying elements)*

------
https://chatgpt.com/codex/tasks/task_e_6875b3f2b83c83209061438d55374fbe