### PR TITLE
Add example setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@ cargo install --path .
 ```
 This will install the `taskter` executable in your Cargo bin directory (usually `~/.cargo/bin/`), which should be in your `PATH`.
 
+## Quick Start Example
+
+You can bootstrap a demo workspace containing sample tasks, an OKR and a test agent by running:
+
+```bash
+./scripts/start_example.sh
+```
+
+The script creates an `example/` directory and builds the project. Once it finishes you can explore the board with:
+
+```bash
+cd example
+../target/release/taskter board
+```
+
 
 ## Usage
 

--- a/scripts/start_example.sh
+++ b/scripts/start_example.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Set up an example Taskter board with sample data.
+
+set -e
+
+# Build the project so we have the taskter binary available.
+cargo build --release
+
+BIN="target/release/taskter"
+
+# Create a fresh example workspace
+rm -rf example
+mkdir example
+cd example
+
+# Initialise a new board
+../$BIN init
+
+# Add a project description
+../$BIN description "Example Taskter project demonstrating basic features."
+
+# Add some tasks
+../$BIN add -t "Set up CI pipeline" -d "Configure continuous integration"
+../$BIN add -t "Write documentation" -d "Document how to use Taskter"
+../$BIN add -t "Prepare first release" -d "Package binaries and publish"
+
+# Add an OKR
+../$BIN add-okr -o "Launch MVP" -k "Complete core features" "Publish docs"
+
+# Prepare a tool description for the demo agent
+cat > email_tool.json <<'JSON'
+{
+  "name": "send_email",
+  "description": "Send an email to a recipient",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "to": {"type": "string"},
+      "subject": {"type": "string"},
+      "body": {"type": "string"}
+    },
+    "required": ["to", "subject", "body"]
+  }
+}
+JSON
+
+# Add the agent and assign it to the first task
+../$BIN add-agent --prompt "You are a helpful email assistant" --tools email_tool.json --model "gemini-pro"
+../$BIN assign --task-id 1 --agent-id 1
+
+# Add a log entry
+../$BIN log "Example project initialised"
+
+echo "Example project created in $(pwd)"

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,10 +1,10 @@
-use serde::{Deserialize, Serialize};
-use std::fs;
-use std::path::Path;
 use crate::store::Task;
 use anyhow::Result;
 use reqwest::Client;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::fs;
+use std::path::Path;
 
 #[derive(Debug, PartialEq)]
 pub enum ExecutionResult {
@@ -144,7 +144,10 @@ fn execute_tool(tool_name: &str, args: &Value) -> Result<String> {
             let subject = args["subject"].as_str().unwrap_or_default();
             let body = args["body"].as_str().unwrap_or_default();
             // This is a placeholder for a real email sending function
-            Ok(format!("Email sent to {} with subject '{}' and body '{}'", to, subject, body))
+            Ok(format!(
+                "Email sent to {} with subject '{}' and body '{}'",
+                to, subject, body
+            ))
         }
         _ => Err(anyhow::anyhow!("Unknown tool: {}", tool_name)),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 //! Taskter library interface exposing the core modules so they can be
 //! reused from integration tests and (potentially) other binaries.
 
-pub mod store;
 pub mod agent;
+pub mod store;
 
 // The TUI heavily depends on a terminal backend which is not easily testable in
 // automated environments. We expose it behind the `tui` feature so that normal
@@ -10,4 +10,3 @@ pub mod agent;
 // unnecessary dependencies on test builds.
 #[cfg(feature = "tui")]
 pub mod tui;
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
 use clap::{Parser, Subcommand};
 use std::fs;
-use std::path::Path;
 use std::io::Write;
+use std::path::Path;
 
+mod agent;
 mod store;
 mod tui;
-mod agent;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,3 +1,5 @@
+use crate::agent::{self, Agent};
+use crate::store::{self, Board, Task, TaskStatus};
 use crossterm::{
     event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
     execute,
@@ -9,8 +11,6 @@ use ratatui::{
     widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
 };
 use std::io;
-use crate::store::{self, Board, Task, TaskStatus};
-use crate::agent::{self, Agent};
 
 enum View {
     Board,
@@ -33,7 +33,11 @@ impl App {
             board,
             agents,
             selected_column: 0,
-            selected_task: [ListState::default(), ListState::default(), ListState::default()],
+            selected_task: [
+                ListState::default(),
+                ListState::default(),
+                ListState::default(),
+            ],
             current_view: View::Board,
             agent_list_state: ListState::default(),
         };
@@ -79,7 +83,11 @@ impl App {
             1 => TaskStatus::InProgress,
             _ => TaskStatus::Done,
         };
-        self.board.tasks.iter().filter(|t| t.status == status).collect()
+        self.board
+            .tasks
+            .iter()
+            .filter(|t| t.status == status)
+            .collect()
     }
 
     fn move_task_to_next_column(&mut self) {
@@ -91,12 +99,13 @@ impl App {
     }
 
     fn move_task(&mut self, direction: i8) {
-        let task_id_to_move = if let Some(selected_index) = self.selected_task[self.selected_column].selected() {
-            let tasks_in_column = self.tasks_in_current_column();
-            tasks_in_column.get(selected_index).map(|t| t.id)
-        } else {
-            None
-        };
+        let task_id_to_move =
+            if let Some(selected_index) = self.selected_task[self.selected_column].selected() {
+                let tasks_in_column = self.tasks_in_current_column();
+                tasks_in_column.get(selected_index).map(|t| t.id)
+            } else {
+                None
+            };
 
         if let Some(task_id) = task_id_to_move {
             if let Some(task) = self.board.tasks.iter_mut().find(|t| t.id == task_id) {
@@ -112,10 +121,11 @@ impl App {
     }
 
     fn get_selected_task(&self) -> Option<&Task> {
-        self.selected_task[self.selected_column].selected()
+        self.selected_task[self.selected_column]
+            .selected()
             .and_then(|selected_index| {
                 let tasks_in_column = self.tasks_in_current_column();
-                tasks_in_column.get(selected_index).map(|t| *t)
+                tasks_in_column.get(selected_index).copied()
             })
     }
 }
@@ -205,7 +215,9 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                         if let Some(selected_agent_index) = app.agent_list_state.selected() {
                             if let Some(agent) = app.agents.get(selected_agent_index).cloned() {
                                 if let Some(task_id) = app.get_selected_task().map(|t| t.id) {
-                                    if let Some(task) = app.board.tasks.iter_mut().find(|t| t.id == task_id) {
+                                    if let Some(task) =
+                                        app.board.tasks.iter_mut().find(|t| t.id == task_id)
+                                    {
                                         task.agent_id = Some(agent.id);
                                         // `execute_task` is asynchronous. We are inside the synchronous
                                         // `run_app` loop which itself is executed from an async Tokio
@@ -214,11 +226,15 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                                         // wait on the future. Using `Handle::current().block_on(...)` keeps
                                         // the API here synchronous without spinning up a brand-new runtime
                                         // each time.
-                                        match tokio::runtime::Handle::current().block_on(agent::execute_task(&agent, task)) {
+                                        match tokio::runtime::Handle::current()
+                                            .block_on(agent::execute_task(&agent, task))
+                                        {
                                             Ok(result) => match result {
                                                 agent::ExecutionResult::Success => {
                                                     task.status = store::TaskStatus::Done;
-                                                    task.comment = Some("Task completed successfully.".to_string());
+                                                    task.comment = Some(
+                                                        "Task completed successfully.".to_string(),
+                                                    );
                                                 }
                                                 agent::ExecutionResult::Failure { comment } => {
                                                     task.status = store::TaskStatus::ToDo;
@@ -228,7 +244,8 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                                             },
                                             Err(_) => {
                                                 task.status = store::TaskStatus::ToDo;
-                                                task.comment = Some("Failed to execute task.".to_string());
+                                                task.comment =
+                                                    Some("Failed to execute task.".to_string());
                                                 task.agent_id = None;
                                             }
                                         }
@@ -258,21 +275,45 @@ fn ui(f: &mut Frame, app: &mut App) {
 fn render_board(f: &mut Frame, app: &mut App) {
     let chunks = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(33), Constraint::Percentage(33), Constraint::Percentage(34)].as_ref())
+        .constraints(
+            [
+                Constraint::Percentage(33),
+                Constraint::Percentage(33),
+                Constraint::Percentage(34),
+            ]
+            .as_ref(),
+        )
         .split(f.size());
 
-    for (i, status) in [TaskStatus::ToDo, TaskStatus::InProgress, TaskStatus::Done].iter().enumerate() {
-        let tasks: Vec<ListItem> = app.board.tasks.iter().filter(|t| t.status == *status).map(|t| {
-            let title = if t.agent_id.is_some() {
-                format!("* {}", t.title)
-            } else {
-                t.title.clone()
-            };
-            ListItem::new(title)
-        }).collect();
-        let mut list = List::new(tasks).block(Block::default().title(format!("{:?}", status)).borders(Borders::ALL));
+    for (i, status) in [TaskStatus::ToDo, TaskStatus::InProgress, TaskStatus::Done]
+        .iter()
+        .enumerate()
+    {
+        let tasks: Vec<ListItem> = app
+            .board
+            .tasks
+            .iter()
+            .filter(|t| t.status == *status)
+            .map(|t| {
+                let title = if t.agent_id.is_some() {
+                    format!("* {}", t.title)
+                } else {
+                    t.title.clone()
+                };
+                ListItem::new(title)
+            })
+            .collect();
+        let mut list = List::new(tasks).block(
+            Block::default()
+                .title(format!("{:?}", status))
+                .borders(Borders::ALL),
+        );
         if app.selected_column == i {
-            list = list.highlight_style(Style::default().add_modifier(Modifier::BOLD).bg(Color::Blue));
+            list = list.highlight_style(
+                Style::default()
+                    .add_modifier(Modifier::BOLD)
+                    .bg(Color::Blue),
+            );
         }
         f.render_stateful_widget(list, chunks[i], &mut app.selected_task[i]);
     }
@@ -299,7 +340,9 @@ fn render_task_description(f: &mut Frame, app: &mut App) {
             )));
         }
 
-        let block = Block::default().title("Task Description").borders(Borders::ALL);
+        let block = Block::default()
+            .title("Task Description")
+            .borders(Borders::ALL);
         let paragraph = Paragraph::new(text).block(block).wrap(Wrap { trim: true });
         let area = centered_rect(60, 25, f.size());
         f.render_widget(Clear, area); //this clears the background
@@ -309,9 +352,7 @@ fn render_task_description(f: &mut Frame, app: &mut App) {
 
 fn render_assign_agent(f: &mut Frame, app: &mut App) {
     if app.agents.is_empty() {
-        let block = Block::default()
-            .title("Assign Agent")
-            .borders(Borders::ALL);
+        let block = Block::default().title("Assign Agent").borders(Borders::ALL);
         let text = Paragraph::new("No agents available. Create one with `taskter add-agent`")
             .block(block)
             .wrap(Wrap { trim: true });
@@ -328,11 +369,7 @@ fn render_assign_agent(f: &mut Frame, app: &mut App) {
         .collect();
 
     let agent_list = List::new(agents)
-        .block(
-            Block::default()
-                .title("Assign Agent")
-                .borders(Borders::ALL),
-        )
+        .block(Block::default().title("Assign Agent").borders(Borders::ALL))
         .highlight_style(
             Style::default()
                 .add_modifier(Modifier::BOLD)

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,8 +1,8 @@
 use std::fs;
 
-use taskter::store::{self, TaskStatus, Task, Board, Okr, KeyResult};
-use taskter::agent::{self, Agent, FunctionDeclaration, ExecutionResult};
 use serde_json::json;
+use taskter::agent::{self, Agent, ExecutionResult, FunctionDeclaration};
+use taskter::store::{self, Board, KeyResult, Okr, Task, TaskStatus};
 
 // Helper that creates a temporary workspace and changes the current directory to it.
 fn with_temp_dir<F: FnOnce() -> T, T>(test: F) -> T {
@@ -32,7 +32,9 @@ fn board_roundtrip_persists_tasks() {
             comment: None,
         };
 
-        let board = Board { tasks: vec![task.clone()] };
+        let board = Board {
+            tasks: vec![task.clone()],
+        };
 
         // When
         store::save_board(&board).expect("failed to save board");
@@ -50,7 +52,10 @@ fn okr_roundtrip_persists_data() {
         // Given
         let okr = Okr {
             objective: "Improve UX".to_string(),
-            key_results: vec![KeyResult { name: "Reduce load time".to_string(), progress: 0.2 }],
+            key_results: vec![KeyResult {
+                name: "Reduce load time".to_string(),
+                progress: 0.2,
+            }],
         };
 
         // When
@@ -86,7 +91,9 @@ async fn agent_executes_email_task_successfully() {
     };
 
     // When
-    let result = agent::execute_task(&agent, &task).await.expect("execution failed");
+    let result = agent::execute_task(&agent, &task)
+        .await
+        .expect("execution failed");
 
     // Then
     matches!(result, ExecutionResult::Success);
@@ -113,7 +120,9 @@ async fn agent_execution_fails_without_tool() {
     };
 
     // When
-    let result = agent::execute_task(&agent, &task).await.expect("execution failed");
+    let result = agent::execute_task(&agent, &task)
+        .await
+        .expect("execution failed");
 
     // Then
     assert!(matches!(result, ExecutionResult::Failure { .. }));


### PR DESCRIPTION
## Summary
- add a shell script to bootstrap a demo Taskter board
- document the example script in README
- fix a Clippy lint in TUI
- format codebase with `cargo fmt`

## Testing
- `./scripts/precommit.sh`

------
https://chatgpt.com/codex/tasks/task_e_6875b307dd548320b55c9a9163a25bf1