### PR TITLE
Add task commenting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ In the interactive board, you can use the following keys:
 - `↑` / `↓`: Navigate between tasks
 - `h` / `l`: Move a task to the previous/next column
 - `a`: Assign an agent to the selected task
+- `c`: Add a comment to the selected task
 
 ### Manage tasks
 
@@ -103,6 +104,10 @@ In the interactive board, you can use the following keys:
 - **Mark a task as done:**
   ```bash
   taskter done <task_id>
+  ```
+- **Add a comment to a task:**
+  ```bash
+  taskter comment --task-id <task_id> --comment "Your note"
   ```
 
 ### Project information

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,15 @@ enum Commands {
         /// The id of the task to mark as done
         id: usize,
     },
+    /// Adds a comment to a task
+    Comment {
+        /// The id of the task to comment on
+        #[arg(short, long)]
+        task_id: usize,
+        /// The comment text
+        #[arg(short, long)]
+        comment: String,
+    },
     /// Show project information
     Show {
         #[command(subcommand)]
@@ -164,6 +173,16 @@ async fn main() -> anyhow::Result<()> {
                 println!("Task {} marked as done.", id);
             } else {
                 println!("Task with id {} not found.", id);
+            }
+        }
+        Commands::Comment { task_id, comment } => {
+            let mut board = store::load_board()?;
+            if let Some(task) = board.tasks.iter_mut().find(|t| t.id == *task_id) {
+                task.comment = Some(comment.clone());
+                store::save_board(&board)?;
+                println!("Comment added to task {}.", task_id);
+            } else {
+                println!("Task with id {} not found.", task_id);
             }
         }
         Commands::Show { what } => match what {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -200,6 +200,8 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                         if app.get_selected_task().is_some() {
                             app.current_view = View::AddComment;
                             app.comment_input.clear();
+                        }
+                    }
                     KeyCode::Char('n') => {
                         app.new_task_title.clear();
                         app.new_task_description.clear();
@@ -329,6 +331,9 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                     }
                     KeyCode::Char(c) => {
                         app.comment_input.push(c);
+                    }
+                    _ => {}
+                },
                 View::AddTask => match key.code {
                     KeyCode::Char(c) => {
                         if app.editing_description {
@@ -548,6 +553,9 @@ fn render_add_comment(f: &mut Frame, app: &mut App) {
         .block(block)
         .wrap(Wrap { trim: true });
     let area = centered_rect(60, 25, f.area());
+    f.render_widget(Clear, area);
+    f.render_widget(paragraph, area);
+}
 
 fn render_add_task(f: &mut Frame, app: &mut App) {
     let block = Block::default().title("New Task").borders(Borders::ALL);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -67,6 +67,30 @@ fn okr_roundtrip_persists_data() {
     });
 }
 
+#[test]
+fn comment_roundtrip_persists_changes() {
+    with_temp_dir(|| {
+        let mut board = Board {
+            tasks: vec![Task {
+                id: 1,
+                title: "Test".to_string(),
+                description: None,
+                status: TaskStatus::ToDo,
+                agent_id: None,
+                comment: None,
+            }],
+        };
+
+        store::save_board(&board).expect("failed to save board");
+
+        board.tasks[0].comment = Some("note".to_string());
+        store::save_board(&board).expect("failed to save board");
+
+        let loaded = store::load_board().expect("failed to load board");
+        assert_eq!(loaded.tasks[0].comment.as_deref(), Some("note"));
+    });
+}
+
 #[tokio::test]
 async fn agent_executes_email_task_successfully() {
     // Given


### PR DESCRIPTION
## Summary
- allow adding comments to tasks via `comment` subcommand
- support adding comments from the TUI with `c`
- document the new feature in the README
- test board comment persistence

## Testing
- `./scripts/precommit.sh`

------
https://chatgpt.com/codex/tasks/task_e_6878483182d88320accb5e56dc497376