### PR TITLE
Add example project setup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,20 @@ All agents will use the same configuration file. If the file is missing, the
 `send_email` tool will gracefully fall back to a no-op so tests and offline
 usage keep working.
 
+### Example project
+
+If you want to see Taskter in action without manually creating data, run the
+provided helper script:
+
+```bash
+./scripts/setup_example_project.sh
+```
+
+The script removes any existing `.taskter` directory, creates a new board with a
+few example tasks, sets a project description, defines OKRs and adds an agent
+using the built-in email tool. Once it finishes you can inspect the board with
+`taskter list` or launch the TUI via `taskter board`.
+
 ## Development
 
 Run the included helper script before committing changes to ensure the code is

--- a/scripts/setup_example_project.sh
+++ b/scripts/setup_example_project.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+# Start from a clean board
+rm -rf .taskter
+
+# Initialize project board
+taskter init
+
+# Project description
+taskter description "Example project demonstrating Taskter features."
+
+# Add example tasks
+taskter add -t "Write documentation" -d "Describe how to use Taskter."
+taskter add -t "Plan v1 release" -d "Define scope and timeline."
+taskter add -t "Send status email" -d "Notify stakeholders about progress."
+
+# Define OKRs
+taskter add-okr -o "Deliver MVP" -k "Ship v1" "Collect user feedback"
+
+# Create an agent with the built-in email tool
+taskter add-agent --prompt "You are a helpful assistant." --tools email --model "gemini-pro"
+
+# Assign agent to the email task
+taskter assign --task-id 3 --agent-id 1
+
+cat <<MSG
+Example board initialized. Run 'taskter list' or 'taskter board' to explore.
+MSG


### PR DESCRIPTION
## Summary
- document an example project script in the README
- add `setup_example_project.sh` to create a demo board with tasks, OKRs and an agent

## Testing
- `./scripts/precommit.sh`

------
https://chatgpt.com/codex/tasks/task_e_687848b283d88320856bec84c39707d2