### PR TITLE
Add tools to query board state

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ Taskter now supports LLM-based agents that can be assigned to tasks. These agent
   The `--tools` option accepts either paths to JSON files describing a tool or
   the name of a built-in tool. Built-ins live under the `tools/` directory of
   the repository. For example `email` resolves to `tools/send_email.json`.
+  Other built-ins include `create_task`, `assign_agent`, `add_log`, `add_okr`,
+  `list_tasks`, `list_agents`, and `get_project_description`.
 
 - **Assign an agent to a task:**
   ```bash

--- a/src/tools/add_log.rs
+++ b/src/tools/add_log.rs
@@ -1,0 +1,24 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use std::fs::OpenOptions;
+use std::io::Write;
+
+use crate::agent::FunctionDeclaration;
+
+const DECL_JSON: &str = include_str!("../../tools/add_log.json");
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid add_log.json")
+}
+
+pub fn execute(args: &Value) -> Result<String> {
+    let message = args["message"]
+        .as_str()
+        .ok_or_else(|| anyhow!("message missing"))?;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(".taskter/logs.log")?;
+    writeln!(file, "{}", message)?;
+    Ok("Log entry added".to_string())
+}

--- a/src/tools/add_okr.rs
+++ b/src/tools/add_okr.rs
@@ -1,0 +1,38 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+
+use crate::agent::FunctionDeclaration;
+use crate::store::{self, KeyResult, Okr};
+
+const DECL_JSON: &str = include_str!("../../tools/add_okr.json");
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid add_okr.json")
+}
+
+pub fn execute(args: &Value) -> Result<String> {
+    let objective = args["objective"]
+        .as_str()
+        .ok_or_else(|| anyhow!("objective missing"))?;
+    let key_results = args["key_results"]
+        .as_array()
+        .ok_or_else(|| anyhow!("key_results missing"))?;
+
+    let mut okrs = store::load_okrs()?;
+    let mut kr_list = Vec::new();
+    for kr in key_results {
+        if let Some(name) = kr.as_str() {
+            kr_list.push(KeyResult {
+                name: name.to_string(),
+                progress: 0.0,
+            });
+        }
+    }
+
+    okrs.push(Okr {
+        objective: objective.to_string(),
+        key_results: kr_list,
+    });
+    store::save_okrs(&okrs)?;
+    Ok(format!("Added OKR '{}'", objective))
+}

--- a/src/tools/assign_agent.rs
+++ b/src/tools/assign_agent.rs
@@ -1,0 +1,34 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+
+use crate::agent::{self, FunctionDeclaration};
+use crate::store;
+
+const DECL_JSON: &str = include_str!("../../tools/assign_agent.json");
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid assign_agent.json")
+}
+
+pub fn execute(args: &Value) -> Result<String> {
+    let task_id = args["task_id"]
+        .as_u64()
+        .ok_or_else(|| anyhow!("task_id missing"))? as usize;
+    let agent_id = args["agent_id"]
+        .as_u64()
+        .ok_or_else(|| anyhow!("agent_id missing"))? as usize;
+
+    let agents = agent::load_agents()?;
+    if !agents.iter().any(|a| a.id == agent_id) {
+        return Ok(format!("Agent {} not found", agent_id));
+    }
+
+    let mut board = store::load_board()?;
+    if let Some(task) = board.tasks.iter_mut().find(|t| t.id == task_id) {
+        task.agent_id = Some(agent_id);
+        store::save_board(&board)?;
+        Ok(format!("Agent {} assigned to task {}", agent_id, task_id))
+    } else {
+        Ok(format!("Task {} not found", task_id))
+    }
+}

--- a/src/tools/create_task.rs
+++ b/src/tools/create_task.rs
@@ -1,0 +1,35 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+
+use crate::agent::FunctionDeclaration;
+use crate::store::{self, Task, TaskStatus};
+
+const DECL_JSON: &str = include_str!("../../tools/create_task.json");
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid create_task.json")
+}
+
+pub fn execute(args: &Value) -> Result<String> {
+    let title = args["title"]
+        .as_str()
+        .ok_or_else(|| anyhow!("title missing"))?;
+    let description = args
+        .get("description")
+        .and_then(|d| d.as_str())
+        .map(String::from);
+
+    let mut board = store::load_board()?;
+    let id = board.tasks.len() + 1;
+    let task = Task {
+        id,
+        title: title.to_string(),
+        description,
+        status: TaskStatus::ToDo,
+        agent_id: None,
+        comment: None,
+    };
+    board.tasks.push(task);
+    store::save_board(&board)?;
+    Ok(format!("Created task {}", id))
+}

--- a/src/tools/get_description.rs
+++ b/src/tools/get_description.rs
@@ -1,0 +1,16 @@
+use anyhow::Result;
+use serde_json::Value;
+use std::fs;
+
+use crate::agent::FunctionDeclaration;
+
+const DECL_JSON: &str = include_str!("../../tools/get_description.json");
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid get_description.json")
+}
+
+pub fn execute(_args: &Value) -> Result<String> {
+    let content = fs::read_to_string(".taskter/description.md")?;
+    Ok(content)
+}

--- a/src/tools/list_agents.rs
+++ b/src/tools/list_agents.rs
@@ -1,0 +1,15 @@
+use anyhow::Result;
+use serde_json::Value;
+
+use crate::agent::{self, FunctionDeclaration};
+
+const DECL_JSON: &str = include_str!("../../tools/list_agents.json");
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid list_agents.json")
+}
+
+pub fn execute(_args: &Value) -> Result<String> {
+    let agents = agent::list_agents()?;
+    Ok(serde_json::to_string_pretty(&agents)?)
+}

--- a/src/tools/list_tasks.rs
+++ b/src/tools/list_tasks.rs
@@ -1,0 +1,16 @@
+use anyhow::Result;
+use serde_json::Value;
+
+use crate::agent::FunctionDeclaration;
+use crate::store;
+
+const DECL_JSON: &str = include_str!("../../tools/list_tasks.json");
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid list_tasks.json")
+}
+
+pub fn execute(_args: &Value) -> Result<String> {
+    let board = store::load_board()?;
+    Ok(serde_json::to_string_pretty(&board.tasks)?)
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -3,11 +3,25 @@ use serde_json::Value;
 
 use crate::agent::FunctionDeclaration;
 
+pub mod add_log;
+pub mod add_okr;
+pub mod assign_agent;
+pub mod create_task;
 pub mod email;
+pub mod get_description;
+pub mod list_agents;
+pub mod list_tasks;
 
 pub fn builtin_declaration(name: &str) -> Option<FunctionDeclaration> {
     match name {
         "send_email" | "email" => Some(email::declaration()),
+        "create_task" => Some(create_task::declaration()),
+        "assign_agent" => Some(assign_agent::declaration()),
+        "add_log" => Some(add_log::declaration()),
+        "add_okr" => Some(add_okr::declaration()),
+        "list_tasks" => Some(list_tasks::declaration()),
+        "list_agents" => Some(list_agents::declaration()),
+        "get_project_description" => Some(get_description::declaration()),
         _ => None,
     }
 }
@@ -15,6 +29,13 @@ pub fn builtin_declaration(name: &str) -> Option<FunctionDeclaration> {
 pub fn execute_tool(name: &str, args: &Value) -> Result<String> {
     match name {
         "send_email" | "email" => email::execute(args),
+        "create_task" => create_task::execute(args),
+        "assign_agent" => assign_agent::execute(args),
+        "add_log" => add_log::execute(args),
+        "add_okr" => add_okr::execute(args),
+        "list_tasks" => list_tasks::execute(args),
+        "list_agents" => list_agents::execute(args),
+        "get_project_description" => get_description::execute(args),
         _ => Err(anyhow::anyhow!("Unknown tool: {}", name)),
     }
 }

--- a/tools/add_log.json
+++ b/tools/add_log.json
@@ -1,0 +1,11 @@
+{
+  "name": "add_log",
+  "description": "Add an entry to the operation log",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "message": { "type": "string", "description": "Log message" }
+    },
+    "required": ["message"]
+  }
+}

--- a/tools/add_okr.json
+++ b/tools/add_okr.json
@@ -1,0 +1,12 @@
+{
+  "name": "add_okr",
+  "description": "Add a new objective with key results to the OKR list",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "objective": { "type": "string", "description": "Objective text" },
+      "key_results": { "type": "array", "items": { "type": "string" }, "description": "Key results to track" }
+    },
+    "required": ["objective", "key_results"]
+  }
+}

--- a/tools/assign_agent.json
+++ b/tools/assign_agent.json
@@ -1,0 +1,12 @@
+{
+  "name": "assign_agent",
+  "description": "Assign an agent to an existing task",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "task_id": { "type": "integer", "description": "ID of the task" },
+      "agent_id": { "type": "integer", "description": "ID of the agent" }
+    },
+    "required": ["task_id", "agent_id"]
+  }
+}

--- a/tools/create_task.json
+++ b/tools/create_task.json
@@ -1,0 +1,12 @@
+{
+  "name": "create_task",
+  "description": "Create a new task in the Taskter board",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "title": { "type": "string", "description": "Task title" },
+      "description": { "type": "string", "description": "Task description" }
+    },
+    "required": ["title"]
+  }
+}

--- a/tools/get_description.json
+++ b/tools/get_description.json
@@ -1,0 +1,9 @@
+{
+  "name": "get_project_description",
+  "description": "Retrieve the project description text",
+  "parameters": {
+    "type": "object",
+    "properties": {},
+    "required": []
+  }
+}

--- a/tools/list_agents.json
+++ b/tools/list_agents.json
@@ -1,0 +1,9 @@
+{
+  "name": "list_agents",
+  "description": "Return the current list of agents in JSON form",
+  "parameters": {
+    "type": "object",
+    "properties": {},
+    "required": []
+  }
+}

--- a/tools/list_tasks.json
+++ b/tools/list_tasks.json
@@ -1,0 +1,9 @@
+{
+  "name": "list_tasks",
+  "description": "Return the current list of tasks in JSON form",
+  "parameters": {
+    "type": "object",
+    "properties": {},
+    "required": []
+  }
+}


### PR DESCRIPTION
## Summary
- support listing tasks and agents
- add tool to read project description
- document new built-ins

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6878484976908320a8ad08dabf49bc7d