### PR TITLE
Add CLI integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +164,17 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -253,7 +280,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -356,6 +383,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,6 +398,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
@@ -410,7 +449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -418,6 +457,15 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fnv"
@@ -1072,10 +1120,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_threads"
@@ -1226,6 +1289,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -1426,7 +1519,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1439,7 +1532,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1749,10 +1842,12 @@ name = "taskter"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "clap",
  "crossterm",
  "lettre",
  "mockito",
+ "predicates",
  "ratatui",
  "reqwest",
  "serde",
@@ -1771,8 +1866,14 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "time"
@@ -2014,6 +2115,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,5 @@ tui = []
 [dev-dependencies]
 mockito = "1.4.0"
 tempfile = "3"
+assert_cmd = "2.0.17"
+predicates = "3.1.3"

--- a/tests/cli_commands.rs
+++ b/tests/cli_commands.rs
@@ -1,0 +1,90 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde_json::Value;
+use std::fs;
+
+fn with_temp_dir<F: FnOnce() -> T, T>(test: F) -> T {
+    let tmp = tempfile::tempdir().expect("failed to create temp dir");
+    let original_dir = std::env::current_dir().expect("cannot read current dir");
+    std::env::set_current_dir(tmp.path()).expect("cannot set current dir");
+
+    let result = test();
+
+    std::env::set_current_dir(original_dir).expect("cannot restore current dir");
+    result
+}
+
+#[test]
+fn add_list_done_workflow() {
+    with_temp_dir(|| {
+        // Initialize board
+        Command::cargo_bin("taskter").unwrap()
+            .arg("init")
+            .assert()
+            .success();
+
+        // Add a task
+        Command::cargo_bin("taskter").unwrap()
+            .args(["add", "--title", "Test task"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Task added successfully"));
+
+        // Verify list output contains the task
+        let out = Command::cargo_bin("taskter").unwrap()
+            .arg("list")
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let output = String::from_utf8(out).unwrap();
+        assert!(output.contains("Test task"));
+
+        // Mark the task as done
+        Command::cargo_bin("taskter").unwrap()
+            .args(["done", "1"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("marked as done"));
+
+        // Inspect board file
+        let board: Value = serde_json::from_str(&fs::read_to_string(".taskter/board.json").unwrap()).unwrap();
+        assert_eq!(board["tasks"][0]["status"], "Done");
+    });
+}
+
+#[test]
+fn add_agent_and_execute_task() {
+    with_temp_dir(|| {
+        // prepare board
+        Command::cargo_bin("taskter").unwrap().arg("init").assert().success();
+
+        // add a task
+        Command::cargo_bin("taskter").unwrap()
+            .args(["add", "--title", "Send email"])
+            .assert()
+            .success();
+
+        // add agent with builtin tool
+        Command::cargo_bin("taskter").unwrap()
+            .args(["add-agent", "--prompt", "email agent", "--tools", "email", "--model", "gpt-4o"])
+            .assert()
+            .success();
+
+        // assign agent to task
+        Command::cargo_bin("taskter").unwrap()
+            .args(["assign", "--task-id", "1", "--agent-id", "1"])
+            .assert()
+            .success();
+
+        // execute the task
+        Command::cargo_bin("taskter").unwrap()
+            .args(["execute", "--task-id", "1"])
+            .assert()
+            .success();
+
+        let board: Value = serde_json::from_str(&fs::read_to_string(".taskter/board.json").unwrap()).unwrap();
+        assert_eq!(board["tasks"][0]["status"], "Done");
+    });
+}


### PR DESCRIPTION
## Summary
- add integration tests for CLI commands such as `add`, `list`, `done`, `add-agent`, and `execute`
- use `assert_cmd` and `predicates` to run the taskter binary
- update dependencies

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68790512425883209b502f8f91ec0957