### PR TITLE
Add Gemini API key doc section

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,15 @@ All agents will use the same configuration file. If the file is missing, the
 `send_email` tool will gracefully fall back to a no-op so tests and offline
 usage keep working.
 
+### Gemini API key
+
+Agent execution uses the Gemini API, so the `GEMINI_API_KEY` environment
+variable must be set. For example:
+
+```bash
+export GEMINI_API_KEY=your_key_here
+```
+
 ## Development
 
 Run the included helper script before committing changes to ensure the code is

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -260,7 +260,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                                         // wait on the future. Using `Handle::current().block_on(...)` keeps
                                         // the API here synchronous without spinning up a brand-new runtime
                                         // each time.
-                                      
+
                                         // Calling `Handle::current().block_on(...)` inside an already
                                         // running Tokio runtime panics ("Cannot start a runtime from
                                         // within a runtime").  To remain in the synchronous context of


### PR DESCRIPTION
## Summary
- add a new "Gemini API key" section in the README explaining that `GEMINI_API_KEY` must be set
- format `src/tui.rs` with `cargo fmt`

## Testing
- `./scripts/precommit.sh`

------
https://chatgpt.com/codex/tasks/task_e_6878faf7ea3c83209a3cbe2cdffbf4b5