### PR TITLE
fix: Correct 'get_description' tool name

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Taskter now supports LLM-based agents that can be assigned to tasks. These agent
   the name of a built-in tool. Built-ins live under the `tools/` directory of
   the repository. For example `email` resolves to `tools/send_email.json`.
   Other built-ins include `create_task`, `assign_agent`, `add_log`, `add_okr`,
-  `list_tasks`, `list_agents`, and `get_project_description`.
+  `list_tasks`, `list_agents`, and `get_description`.
 
 - **Assign an agent to a task:**
   ```bash

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,9 +170,9 @@ async fn main() -> anyhow::Result<()> {
             if let Some(task) = board.tasks.iter_mut().find(|t| t.id == *id) {
                 task.status = store::TaskStatus::Done;
                 store::save_board(&board)?;
-                println!("Task {} marked as done.", id);
+                println!("Task {id} marked as done.");
             } else {
-                println!("Task with id {} not found.", id);
+                println!("Task with id {id} not found.");
             }
         }
         Commands::Comment { task_id, comment } => {
@@ -180,23 +180,23 @@ async fn main() -> anyhow::Result<()> {
             if let Some(task) = board.tasks.iter_mut().find(|t| t.id == *task_id) {
                 task.comment = Some(comment.clone());
                 store::save_board(&board)?;
-                println!("Comment added to task {}.", task_id);
+                println!("Comment added to task {task_id}.");
             } else {
-                println!("Task with id {} not found.", task_id);
+                println!("Task with id {task_id} not found.");
             }
         }
         Commands::Show { what } => match what {
             ShowCommands::Description => {
                 let description = fs::read_to_string(".taskter/description.md")?;
-                println!("{}", description);
+                println!("{description}");
             }
             ShowCommands::Okrs => {
                 let okrs = fs::read_to_string(".taskter/okrs.json")?;
-                println!("{}", okrs);
+                println!("{okrs}");
             }
             ShowCommands::Logs => {
                 let logs = fs::read_to_string(".taskter/logs.log")?;
-                println!("{}", logs);
+                println!("{logs}");
             }
         },
         Commands::AddOkr {
@@ -223,7 +223,7 @@ async fn main() -> anyhow::Result<()> {
                 .create(true)
                 .append(true)
                 .open(".taskter/logs.log")?;
-            writeln!(file, "{}", message)?;
+            writeln!(file, "{message}")?;
             println!("Log added successfully.");
         }
         Commands::Board => {
@@ -248,7 +248,7 @@ async fn main() -> anyhow::Result<()> {
                 } else if let Some(built) = tools::builtin_declaration(spec) {
                     built
                 } else {
-                    return Err(anyhow::anyhow!(format!("Unknown tool: {}", spec)));
+                    return Err(anyhow::anyhow!(format!("Unknown tool: {spec}")));
                 };
                 function_declarations.push(decl);
             }
@@ -275,27 +275,27 @@ async fn main() -> anyhow::Result<()> {
                                 agent::ExecutionResult::Success { comment } => {
                                     task.status = store::TaskStatus::Done;
                                     task.comment = Some(comment);
-                                    println!("Task {} executed successfully.", task_id);
+                                    println!("Task {task_id} executed successfully.");
                                 }
                                 agent::ExecutionResult::Failure { comment } => {
                                     task.status = store::TaskStatus::ToDo;
                                     task.comment = Some(comment);
                                     task.agent_id = None;
-                                    println!("Task {} failed to execute.", task_id);
+                                    println!("Task {task_id} failed to execute.");
                                 }
                             },
                             Err(e) => {
-                                println!("Error executing task {}: {}", task_id, e);
+                                println!("Error executing task {task_id}: {e}");
                             }
                         }
                     } else {
-                        println!("Agent with id {} not found.", agent_id);
+                        println!("Agent with id {agent_id} not found.");
                     }
                 } else {
-                    println!("Task {} is not assigned to an agent.", task_id);
+                    println!("Task {task_id} is not assigned to an agent.");
                 }
             } else {
-                println!("Task with id {} not found.", task_id);
+                println!("Task with id {task_id} not found.");
             }
 
             store::save_board(&board)?;
@@ -305,9 +305,9 @@ async fn main() -> anyhow::Result<()> {
             if let Some(task) = board.tasks.iter_mut().find(|t| t.id == *task_id) {
                 task.agent_id = Some(*agent_id);
                 store::save_board(&board)?;
-                println!("Agent {} assigned to task {}.", agent_id, task_id);
+                println!("Agent {agent_id} assigned to task {task_id}.");
             } else {
-                println!("Task with id {} not found.", task_id);
+                println!("Task with id {task_id} not found.");
             }
         }
         Commands::ListAgents => {
@@ -318,7 +318,7 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::DeleteAgent { agent_id } => {
             agent::delete_agent(*agent_id)?;
-            println!("Agent {} deleted.", agent_id);
+            println!("Agent {agent_id} deleted.");
         }
     }
 

--- a/src/tools/add_log.rs
+++ b/src/tools/add_log.rs
@@ -19,6 +19,6 @@ pub fn execute(args: &Value) -> Result<String> {
         .create(true)
         .append(true)
         .open(".taskter/logs.log")?;
-    writeln!(file, "{}", message)?;
+    writeln!(file, "{message}")?;
     Ok("Log entry added".to_string())
 }

--- a/src/tools/add_okr.rs
+++ b/src/tools/add_okr.rs
@@ -34,5 +34,5 @@ pub fn execute(args: &Value) -> Result<String> {
         key_results: kr_list,
     });
     store::save_okrs(&okrs)?;
-    Ok(format!("Added OKR '{}'", objective))
+    Ok(format!("Added OKR '{objective}'"))
 }

--- a/src/tools/assign_agent.rs
+++ b/src/tools/assign_agent.rs
@@ -20,15 +20,15 @@ pub fn execute(args: &Value) -> Result<String> {
 
     let agents = agent::load_agents()?;
     if !agents.iter().any(|a| a.id == agent_id) {
-        return Ok(format!("Agent {} not found", agent_id));
+        return Ok(format!("Agent {agent_id} not found"));
     }
 
     let mut board = store::load_board()?;
     if let Some(task) = board.tasks.iter_mut().find(|t| t.id == task_id) {
         task.agent_id = Some(agent_id);
         store::save_board(&board)?;
-        Ok(format!("Agent {} assigned to task {}", agent_id, task_id))
+        Ok(format!("Agent {agent_id} assigned to task {task_id}"))
     } else {
-        Ok(format!("Task {} not found", task_id))
+        Ok(format!("Task {task_id} not found"))
     }
 }

--- a/src/tools/create_task.rs
+++ b/src/tools/create_task.rs
@@ -31,5 +31,5 @@ pub fn execute(args: &Value) -> Result<String> {
     };
     board.tasks.push(task);
     store::save_board(&board)?;
-    Ok(format!("Created task {}", id))
+    Ok(format!("Created task {id}"))
 }

--- a/src/tools/email.rs
+++ b/src/tools/email.rs
@@ -27,10 +27,9 @@ pub fn execute(args: &Value) -> Result<String> {
     let body = args["body"].as_str().unwrap_or_default();
     match send_email(to, subject, body) {
         Ok(_) => Ok(format!(
-            "Email sent to {} with subject '{}' and body '{}'",
-            to, subject, body
+            "Email sent to {to} with subject '{subject}' and body '{body}'"
         )),
-        Err(e) => Ok(format!("Failed to send email: {}", e)),
+        Err(e) => Ok(format!("Failed to send email: {e}")),
     }
 }
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -21,7 +21,7 @@ pub fn builtin_declaration(name: &str) -> Option<FunctionDeclaration> {
         "add_okr" => Some(add_okr::declaration()),
         "list_tasks" => Some(list_tasks::declaration()),
         "list_agents" => Some(list_agents::declaration()),
-        "get_project_description" => Some(get_description::declaration()),
+        "get_description" => Some(get_description::declaration()),
         _ => None,
     }
 }
@@ -35,7 +35,7 @@ pub fn execute_tool(name: &str, args: &Value) -> Result<String> {
         "add_okr" => add_okr::execute(args),
         "list_tasks" => list_tasks::execute(args),
         "list_agents" => list_agents::execute(args),
-        "get_project_description" => get_description::execute(args),
+        "get_description" => get_description::execute(args),
         _ => Err(anyhow::anyhow!("Unknown tool: {}", name)),
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -162,7 +162,7 @@ pub fn run_tui() -> anyhow::Result<()> {
     terminal.show_cursor()?;
 
     if let Err(err) = res {
-        println!("{:?}", err)
+        println!("{err:?}")
     }
 
     Ok(())
@@ -269,7 +269,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                                         // wait on the future. Using `Handle::current().block_on(...)` keeps
                                         // the API here synchronous without spinning up a brand-new runtime
                                         // each time.
-                                      
+
                                         // Calling `Handle::current().block_on(...)` inside an already
                                         // running Tokio runtime panics ("Cannot start a runtime from
                                         // within a runtime").  To remain in the synchronous context of
@@ -470,7 +470,7 @@ fn render_board(f: &mut Frame, app: &mut App) {
             .collect();
         let mut list = List::new(tasks).block(
             Block::default()
-                .title(format!("{:?}", status))
+                .title(format!("{status:?}"))
                 .borders(Borders::ALL),
         );
         if app.selected_column == i {
@@ -495,12 +495,12 @@ fn render_task_description(f: &mut Frame, app: &mut App) {
         ];
 
         if let Some(agent_id) = task.agent_id {
-            text.push(Line::from(format!("Assigned to agent: {}", agent_id)));
+            text.push(Line::from(format!("Assigned to agent: {agent_id}")));
         }
 
         if let Some(comment) = &task.comment {
             text.push(Line::from(Span::styled(
-                format!("Comment: {}", comment),
+                format!("Comment: {comment}"),
                 Style::default().fg(Color::Yellow),
             )));
         }
@@ -545,7 +545,6 @@ fn render_assign_agent(f: &mut Frame, app: &mut App) {
     f.render_widget(Clear, area);
     f.render_stateful_widget(agent_list, area, &mut app.agent_list_state);
 }
-
 
 fn render_add_comment(f: &mut Frame, app: &mut App) {
     let block = Block::default().title("Add Comment").borders(Borders::ALL);


### PR DESCRIPTION
The 'get_description' tool was inconsistently named 'get_project_description' in the code and README, causing an 'Unknown tool' error. This commit renames it to 'get_description' everywhere for consistency.

Additionally, this commit fixes a new Clippy lint error that required variables to be used directly in format strings.