### PR TITLE
Add mdBook docs and deployment workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,28 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Install mdBook
+        run: cargo install mdbook --version 0.4.37
+      - name: Build book
+        run: mdbook build docs
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/book
+          publish_branch: gh-pages
+

--- a/README.md
+++ b/README.md
@@ -235,3 +235,9 @@ If you want Git to run it automatically, create a pre-commit hook:
 ```bash
 ln -s ../../scripts/precommit.sh .git/hooks/pre-commit
 ```
+
+## Documentation
+
+Rendered documentation is available on GitHub Pages: <https://YOUR_GITHUB_USERNAME.github.io/taskter/>.
+
+To contribute to the book, edit the Markdown files under `docs/src/` and open a pull request. The `Deploy Docs` workflow will rebuild the book and publish it automatically when changes land on `main`.

--- a/README.md
+++ b/README.md
@@ -238,6 +238,6 @@ ln -s ../../scripts/precommit.sh .git/hooks/pre-commit
 
 ## Documentation
 
-Rendered documentation is available on GitHub Pages: <https://YOUR_GITHUB_USERNAME.github.io/taskter/>.
+Rendered documentation is available on GitHub Pages: <https://tomatyss.github.io/taskter/>.
 
 To contribute to the book, edit the Markdown files under `docs/src/` and open a pull request. The `Deploy Docs` workflow will rebuild the book and publish it automatically when changes land on `main`.

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,12 @@
+[book]
+title = "Taskter Documentation"
+author = "Taskter Contributors"
+multilingual = false
+src = "src"
+
+[build]
+build-dir = "book"
+create-missing = true
+
+[output.html]
+default-theme = "light"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,8 @@
+# Summary
+
+- [Overview](overview.md)
+- [Installation](installation.md)
+- [CLI Usage](cli_usage.md)
+- [TUI Guide](tui_guide.md)
+- [Agent System](agent_system.md)
+- [Contributing](contributing.md)

--- a/docs/src/agent_system.md
+++ b/docs/src/agent_system.md
@@ -1,0 +1,3 @@
+# Agent System
+
+Agents can be assigned to tasks to automate their execution using LLM-based tools. Refer to `taskter add-agent --help` for configuration options.

--- a/docs/src/cli_usage.md
+++ b/docs/src/cli_usage.md
@@ -1,0 +1,3 @@
+# CLI Usage
+
+Taskter exposes multiple subcommands. Run `taskter --help` to see the available options. The README lists common workflows.

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -1,0 +1,3 @@
+# Contributing
+
+Documentation is built with [mdBook](https://rust-lang.github.io/mdBook/). Edit the files under `docs/src/` and open a pull request. The GitHub Actions workflow will publish the book automatically.

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -1,0 +1,3 @@
+# Installation
+
+Follow the instructions in the repository README to build Taskter from source or use Docker.

--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -1,0 +1,3 @@
+# Overview
+
+Taskter is a terminal-based Kanban board written in Rust. This book provides an overview of its features and how to use them.

--- a/docs/src/tui_guide.md
+++ b/docs/src/tui_guide.md
@@ -1,0 +1,3 @@
+# TUI Guide
+
+Launch the interactive board with `taskter board`. Use the keyboard shortcuts displayed in the help menu to navigate between tasks and columns.


### PR DESCRIPTION
## Summary
- add mdBook documentation with initial chapters
- document GitHub Pages build workflow
- update README with link and instructions

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68792741d3e8832097196f3354dfc2a2