### PR TITLE
Add run_bash tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Taskter now supports LLM-based agents that can be assigned to tasks. These agent
   the name of a built-in tool. Built-ins live under the `tools/` directory of
   the repository. For example `email` resolves to `tools/send_email.json`.
   Other built-ins include `create_task`, `assign_agent`, `add_log`, `add_okr`,
-  `list_tasks`, `list_agents`, and `get_description`.
+  `list_tasks`, `list_agents`, `get_description`, and `run_bash`.
 
 - **Assign an agent to a task:**
   ```bash

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -11,6 +11,7 @@ pub mod email;
 pub mod get_description;
 pub mod list_agents;
 pub mod list_tasks;
+pub mod run_bash;
 
 pub fn builtin_declaration(name: &str) -> Option<FunctionDeclaration> {
     match name {
@@ -21,6 +22,7 @@ pub fn builtin_declaration(name: &str) -> Option<FunctionDeclaration> {
         "add_okr" => Some(add_okr::declaration()),
         "list_tasks" => Some(list_tasks::declaration()),
         "list_agents" => Some(list_agents::declaration()),
+        "run_bash" => Some(run_bash::declaration()),
         "get_description" => Some(get_description::declaration()),
         _ => None,
     }
@@ -35,6 +37,7 @@ pub fn execute_tool(name: &str, args: &Value) -> Result<String> {
         "add_okr" => add_okr::execute(args),
         "list_tasks" => list_tasks::execute(args),
         "list_agents" => list_agents::execute(args),
+        "run_bash" => run_bash::execute(args),
         "get_description" => get_description::execute(args),
         _ => Err(anyhow::anyhow!("Unknown tool: {}", name)),
     }

--- a/src/tools/run_bash.rs
+++ b/src/tools/run_bash.rs
@@ -1,0 +1,28 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use std::process::Command;
+
+use crate::agent::FunctionDeclaration;
+
+const DECL_JSON: &str = include_str!("../../tools/run_bash.json");
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid run_bash.json")
+}
+
+pub fn execute(args: &Value) -> Result<String> {
+    let command = args["command"]
+        .as_str()
+        .ok_or_else(|| anyhow!("command missing"))?;
+
+    let output = Command::new("sh").arg("-c").arg(command).output()?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        Err(anyhow!(
+            "Command failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ))
+    }
+}

--- a/tools/run_bash.json
+++ b/tools/run_bash.json
@@ -1,0 +1,11 @@
+{
+  "name": "run_bash",
+  "description": "Execute a bash command and return its output",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "command": { "type": "string", "description": "Shell command to execute" }
+    },
+    "required": ["command"]
+  }
+}


### PR DESCRIPTION
## Summary
- add a built‑in tool to execute shell commands
- document the new `run_bash` tool

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6879947c9ff083208e3cc89c14eb7b55