### PR TITLE
Add manage_file tool

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 The Taskter Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT of OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Taskter
 
+[![Test](https://github.com/tomatyss/taskter/actions/workflows/test.yml/badge.svg)](https://github.com/tomatyss/taskter/actions/workflows/test.yml)
+[![Crates.io](https://img.shields.io/crates/v/taskter)](https://crates.io/crates/taskter)
+[![Documentation](https://img.shields.io/badge/docs-gh--pages-informational)](https://tomatyss.github.io/taskter/)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
 Taskter is a terminal Kanban board CLI tool built with Rust.
 
 > **Warning**
@@ -11,6 +16,71 @@ Taskter is a terminal Kanban board CLI tool built with Rust.
 - Project description
 - Operation logs
 - OKRs (Objectives and Key Results)
+
+## Quick Start
+
+This section provides a quick overview of how to get started with Taskter.
+
+### 1. Initialize the board
+
+First, navigate to your project's directory and initialize the Taskter board:
+
+```bash
+taskter init
+```
+
+This will create a `.taskter` directory to store all your tasks, agents, and project data.
+
+### 2. Create an agent
+
+Next, create an agent to help you with your tasks. For this example, we'll create a simple agent that can run bash commands:
+
+```bash
+taskter add-agent --prompt "You are a helpful assistant that can run bash commands." --tools "run_bash" --model "gemini-2.5-pro"
+```
+
+You can list all available agents using:
+
+```bash
+taskter list-agents
+```
+
+### 3. Create a task
+
+Now, let's create a task for your agent to complete:
+
+```bash
+taskter add -t "List files in the current directory" -d "Use the ls -la command to list all files and folders in the current directory."
+```
+
+You can see all your tasks by running:
+
+```bash
+taskter list
+```
+
+### 4. Assign the task to an agent
+
+Assign the newly created task to your agent:
+
+```bash
+taskter assign --task-id 1 --agent-id 1
+```
+
+### 5. Execute the task
+
+Finally, execute the task:
+
+```bash
+taskter execute --task-id 1
+```
+
+The agent will now run the task. If it's successful, the task will be marked as "Done". You can view the board at any time using the interactive UI:
+
+```bash
+taskter board
+```
+
 
 ## Build and Installation
 
@@ -91,6 +161,9 @@ In the interactive board, you can use the following keys:
 - `n`: Create a new task
 - `u`: Edit the selected task
 - `d`: Delete the selected task
+- `L`: View project logs
+- `A`: List available agents
+- `O`: Show OKRs
 
 ### Manage tasks
 
@@ -160,8 +233,8 @@ Taskter now supports LLM-based agents that can be assigned to tasks. These agent
   The `--tools` option accepts either paths to JSON files describing a tool or
   the name of a built-in tool. Built-ins live under the `tools/` directory of
   the repository. For example `email` resolves to `tools/send_email.json`.
-  Other built-ins include `create_task`, `assign_agent`, `add_log`, `add_okr`,
-  `list_tasks`, `list_agents`, `get_description`, and `manage_file`.
+  Other built-ins include `create_task`, `assign_agent`, `add_log`, `add_okr`, `list_tasks`, `list_agents`, `get_description`, `manage_file`, and `run_bash`.
+
 
 - **Assign an agent to a task:**
   ```bash
@@ -252,3 +325,11 @@ ln -s ../../scripts/precommit.sh .git/hooks/pre-commit
 Rendered documentation is available on GitHub Pages: <https://tomatyss.github.io/taskter/>.
 
 To contribute to the book, edit the Markdown files under `docs/src/` and open a pull request. The `Deploy Docs` workflow will rebuild the book and publish it automatically when changes land on `main`.
+
+## Contributing
+
+Contributions are welcome! Please open an issue or submit a pull request.
+
+## License
+
+This project is licensed under the MIT License. See the `LICENSE` file for details.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Taskter now supports LLM-based agents that can be assigned to tasks. These agent
   the name of a built-in tool. Built-ins live under the `tools/` directory of
   the repository. For example `email` resolves to `tools/send_email.json`.
   Other built-ins include `create_task`, `assign_agent`, `add_log`, `add_okr`,
-  `list_tasks`, `list_agents`, and `get_description`.
+  `list_tasks`, `list_agents`, `get_description`, and `manage_file`.
 
 - **Assign an agent to a task:**
   ```bash

--- a/docs/src/agent_system.md
+++ b/docs/src/agent_system.md
@@ -1,3 +1,44 @@
 # Agent System
 
-Agents can be assigned to tasks to automate their execution using LLM-based tools. Refer to `taskter add-agent --help` for configuration options.
+Taskter supports LLM-based agents that can be assigned to tasks. These agents can execute tasks using a mocked Gemini API for tool-calling.
+
+## Creating an Agent
+
+You can create an agent using the `add-agent` subcommand. You need to provide a prompt, a list of tools, and a model.
+
+```bash
+taskter add-agent --prompt "You are a helpful assistant." --tools "email" "calendar" --model "gemini-pro"
+```
+
+The `--tools` option accepts either paths to JSON files describing a tool or the name of a built-in tool. Built-in tools are located in the `tools/` directory of the repository.
+
+Available built-in tools:
+- `create_task`
+- `assign_agent`
+- `add_log`
+- `add_okr`
+- `list_tasks`
+- `list_agents`
+- `get_description`
+- `run_bash`
+- `send_email`
+
+## Assigning an Agent to a Task
+
+Once you have created an agent, you can assign it to a task using the `assign` subcommand:
+
+```bash
+taskter assign --task-id 1 --agent-id 1
+```
+
+## Executing a Task
+
+To execute a task with an assigned agent, use the `execute` subcommand:
+
+```bash
+taskter execute --task-id 1
+```
+
+When a task is executed, the agent will attempt to perform the task. If successful, the task is marked as "Done". If it fails, the task is moved back to "To Do", unassigned, and a comment from the agent is added.
+
+In the interactive board (`taskter board`), tasks assigned to an agent will be marked with a `*`. You can view the assigned agent ID and any comments by selecting the task and pressing `Enter`.

--- a/docs/src/cli_usage.md
+++ b/docs/src/cli_usage.md
@@ -1,3 +1,67 @@
 # CLI Usage
 
 Taskter exposes multiple subcommands. Run `taskter --help` to see the available options. The README lists common workflows.
+
+## Quick Start
+
+This section provides a quick overview of how to get started with Taskter.
+
+### 1. Initialize the board
+
+First, navigate to your project's directory and initialize the Taskter board:
+
+```bash
+taskter init
+```
+
+This will create a `.taskter` directory to store all your tasks, agents, and project data.
+
+### 2. Create an agent
+
+Next, create an agent to help you with your tasks. For this example, we'll create a simple agent that can run bash commands:
+
+```bash
+taskter add-agent --prompt "You are a helpful assistant that can run bash commands." --tools "run_bash" --model "gemini-pro"
+```
+
+You can list all available agents using:
+
+```bash
+taskter list-agents
+```
+
+### 3. Create a task
+
+Now, let's create a task for your agent to complete:
+
+```bash
+taskter add -t "List files in the current directory" -d "Use the ls -la command to list all files and folders in the current directory."
+```
+
+You can see all your tasks by running:
+
+```bash
+taskter list
+```
+
+### 4. Assign the task to an agent
+
+Assign the newly created task to your agent:
+
+```bash
+taskter assign --task-id 1 --agent-id 1
+```
+
+### 5. Execute the task
+
+Finally, execute the task:
+
+```bash
+taskter execute --task-id 1
+```
+
+The agent will now run the task. If it's successful, the task will be marked as "Done". You can view the board at any time using the interactive UI:
+
+```bash
+taskter board
+```

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -1,3 +1,35 @@
 # Contributing
 
-Documentation is built with [mdBook](https://rust-lang.github.io/mdBook/). Edit the files under `docs/src/` and open a pull request. The GitHub Actions workflow will publish the book automatically.
+Contributions are welcome! This guide will help you get started with setting up your development environment and submitting your changes.
+
+## Development Environment
+
+To contribute to Taskter, you'll need to have Rust and Cargo installed. If you haven't already, follow the instructions at [rust-lang.org](https://www.rust-lang.org/tools/install).
+
+Once you have Rust set up, clone the repository and navigate to the project directory:
+
+```bash
+git clone https://github.com/tomatyss/taskter.git
+cd taskter
+```
+
+## Pre-commit checks
+
+Before committing any changes, please run the pre-commit script to ensure your code is formatted, linted, and passes all tests:
+
+```bash
+./scripts/precommit.sh
+```
+
+You can also set this up as a pre-commit hook to run automatically:
+
+```bash
+ln -s ../../scripts/precommit.sh .git/hooks/pre-commit
+```
+
+## Documentation
+
+The documentation is built with [mdBook](https://rust-lang.github.io/mdBook/). To contribute to the docs, edit the Markdown files under the `docs/src/` directory.
+
+When you're ready, open a pull request with your changes. The GitHub Actions workflow will automatically build and publish the book when your changes are merged into the `main` branch.
+

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -1,3 +1,49 @@
 # Installation
 
-Follow the instructions in the repository README to build Taskter from source or use Docker.
+You can install Taskter either by building from source or using Docker.
+
+## Build from Source
+
+To build Taskter from source, you need to have Rust and Cargo installed.
+
+1.  Clone the repository:
+    ```bash
+    git clone https://github.com/tomatyss/taskter.git
+    cd taskter
+    ```
+
+2.  Build the project:
+    ```bash
+    cargo build --release
+    ```
+    The executable will be located at `target/release/taskter`.
+
+3.  Install the executable:
+    You can make `taskter` available system-wide by copying it to a directory in your system's `PATH`. For example, on macOS or Linux:
+    ```bash
+    sudo cp target/release/taskter /usr/local/bin/taskter
+    ```
+    Alternatively, you can use `cargo install`:
+    ```bash
+    cargo install --path .
+    ```
+    This will install the `taskter` executable in your Cargo bin directory (`~/.cargo/bin/`), which should be in your `PATH`.
+
+## Docker
+
+If you prefer to use Docker, you can build and run Taskter without installing Rust locally.
+
+1.  Build the Docker image:
+    ```bash
+    docker build -t taskter .
+    ```
+
+2.  Run the application:
+    ```bash
+    docker compose run --rm taskter --help
+    ```
+    If you plan to use the Gemini integration for agents, you'll need to pass your API key as an environment variable:
+    ```bash
+    GEMINI_API_KEY=<your_key> docker compose run --rm taskter --help
+    ```
+

--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -1,3 +1,15 @@
 # Overview
 
-Taskter is a terminal-based Kanban board written in Rust. This book provides an overview of its features and how to use them.
+Taskter is a powerful, terminal-based Kanban board designed for developers, project managers, and anyone who prefers to manage their tasks directly from the command line. Built with Rust, Taskter is a lightweight and efficient tool that helps you keep track of your projects without leaving the terminal.
+
+## Key Features
+
+- **Kanban Board**: Visualize your workflow with ToDo, In-Progress, and Done columns.
+- **Task Management**: Add, edit, delete, and manage tasks with simple commands.
+- **Agent System**: Automate tasks using LLM-based agents with tool-calling capabilities.
+- **Project Tracking**: Keep track of your project's description, objectives, and key results (OKRs).
+- **Operation Logs**: Maintain a log of all operations performed on the board.
+- **Interactive TUI**: A user-friendly terminal interface for easy navigation and task management.
+
+This book serves as the official documentation for Taskter, providing a comprehensive guide to its features and usage. Whether you're a new user or a seasoned developer, this guide will help you get the most out of Taskter.
+

--- a/docs/src/tui_guide.md
+++ b/docs/src/tui_guide.md
@@ -1,3 +1,28 @@
 # TUI Guide
 
-Launch the interactive board with `taskter board`. Use the keyboard shortcuts displayed in the help menu to navigate between tasks and columns.
+Taskter's interactive Terminal User Interface (TUI) provides a visual way to manage your Kanban board. To launch it, run:
+
+```bash
+taskter board
+```
+
+## Keybindings
+
+The TUI is controlled with keyboard shortcuts. Here is a list of the available keybindings:
+
+| Key(s)              | Action                               |
+| ------------------- | ------------------------------------ |
+| `q`                 | Quit the application                 |
+| `←` / `→` or `Tab`  | Navigate between columns             |
+| `↑` / `↓`           | Navigate between tasks in a column   |
+| `h` / `l`           | Move a selected task to the next or previous column |
+| `n`                 | Create a new task                    |
+| `u`                 | Edit the selected task               |
+| `d`                 | Delete the selected task             |
+| `a`                 | Assign an agent to the selected task |
+| `c`                 | Add a comment to the selected task   |
+| `L`                 | View project logs                    |
+| `A`                 | List available agents                |
+| `O`                 | Show project OKRs                    |
+
+When a task is selected, you can press `Enter` to view its details, including the full description, any comments, and the assigned agent ID.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -5,6 +5,8 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::fs;
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::Path;
 
 #[derive(Debug, PartialEq)]
@@ -13,8 +15,21 @@ pub enum ExecutionResult {
     Failure { comment: String },
 }
 
+fn append_log(message: &str) -> Result<()> {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(".taskter/logs.log")?;
+    writeln!(file, "{}", message)?;
+    Ok(())
+}
+
 pub async fn execute_task(agent: &Agent, task: &Task) -> Result<ExecutionResult> {
     let client = Client::new();
+    let _ = append_log(&format!(
+        "Agent {} executing task {}: {}",
+        agent.id, task.id, task.title
+    ));
     // Obtain the API key if it is available.  In a testing or offline environment the
     // variable is typically missing.  Rather than crashing the whole process with
     // `expect`, we fall back to a mocked implementation that evaluates the task purely
@@ -38,13 +53,18 @@ pub async fn execute_task(agent: &Agent, task: &Task) -> Result<ExecutionResult>
     // available, otherwise fail.
     if api_key.is_none() {
         if has_send_email_tool {
-            return Ok(ExecutionResult::Success {
-                comment: "No API key found. Task considered complete.".to_string(),
-            });
+            let _ = append_log("Executing without API key - success via built-in tool");
+            let msg = "No API key found. Task considered complete.".to_string();
+            let _ = append_log(&format!(
+                "Agent {} finished successfully: {}",
+                agent.id, msg
+            ));
+            return Ok(ExecutionResult::Success { comment: msg });
         } else {
-            return Ok(ExecutionResult::Failure {
-                comment: "Required tool not available.".to_string(),
-            });
+            let _ = append_log("Executing without API key - required tool missing");
+            let msg = "Required tool not available.".to_string();
+            let _ = append_log(&format!("Agent {} failed: {}", agent.id, msg));
+            return Ok(ExecutionResult::Failure { comment: msg });
         }
     }
 
@@ -87,14 +107,18 @@ pub async fn execute_task(agent: &Agent, task: &Task) -> Result<ExecutionResult>
         {
             Ok(resp) => resp,
             Err(_) => {
+                let _ = append_log("API request failed; falling back to local simulation");
                 return Ok(if has_send_email_tool {
-                    ExecutionResult::Success {
-                        comment: "Tool available. Task considered complete.".to_string(),
-                    }
+                    let msg = "Tool available. Task considered complete.".to_string();
+                    let _ = append_log(&format!(
+                        "Agent {} finished successfully: {}",
+                        agent.id, msg
+                    ));
+                    ExecutionResult::Success { comment: msg }
                 } else {
-                    ExecutionResult::Failure {
-                        comment: "Required tool not available.".to_string(),
-                    }
+                    let msg = "Required tool not available.".to_string();
+                    let _ = append_log(&format!("Agent {} failed: {}", agent.id, msg));
+                    ExecutionResult::Failure { comment: msg }
                 });
             }
         };
@@ -103,28 +127,37 @@ pub async fn execute_task(agent: &Agent, task: &Task) -> Result<ExecutionResult>
             // When the API rejects the request (for example due to an invalid key)
             // we once again fall back to the local simulation.  This keeps normal
             // development and CI runs independent from external services.
+            let _ = append_log("API returned error status; falling back to local simulation");
             return Ok(if has_send_email_tool {
-                ExecutionResult::Success {
-                    comment: "Tool available. Task considered complete.".to_string(),
-                }
+                let msg = "Tool available. Task considered complete.".to_string();
+                let _ = append_log(&format!(
+                    "Agent {} finished successfully: {}",
+                    agent.id, msg
+                ));
+                ExecutionResult::Success { comment: msg }
             } else {
-                ExecutionResult::Failure {
-                    comment: "Required tool not available.".to_string(),
-                }
+                let msg = "Required tool not available.".to_string();
+                let _ = append_log(&format!("Agent {} failed: {}", agent.id, msg));
+                ExecutionResult::Failure { comment: msg }
             });
         }
 
         let response_json: Value = match response.json().await {
             Ok(json) => json,
             Err(_) => {
+                let _ =
+                    append_log("Failed to parse API response; falling back to local simulation");
                 return Ok(if has_send_email_tool {
-                    ExecutionResult::Success {
-                        comment: "Tool available. Task considered complete.".to_string(),
-                    }
+                    let msg = "Tool available. Task considered complete.".to_string();
+                    let _ = append_log(&format!(
+                        "Agent {} finished successfully: {}",
+                        agent.id, msg
+                    ));
+                    ExecutionResult::Success { comment: msg }
                 } else {
-                    ExecutionResult::Failure {
-                        comment: "Required tool not available.".to_string(),
-                    }
+                    let msg = "Required tool not available.".to_string();
+                    let _ = append_log(&format!("Agent {} failed: {}", agent.id, msg));
+                    ExecutionResult::Failure { comment: msg }
                 });
             }
         };
@@ -135,7 +168,15 @@ pub async fn execute_task(agent: &Agent, task: &Task) -> Result<ExecutionResult>
         if let Some(function_call) = part.get("functionCall") {
             let tool_name = function_call["name"].as_str().unwrap();
             let args = &function_call["args"];
+            let _ = append_log(&format!(
+                "Agent {} calling tool {} with args {}",
+                agent.id, tool_name, args
+            ));
             let tool_response = tools::execute_tool(tool_name, args)?;
+            let _ = append_log(&format!(
+                "Tool {} responded with {}",
+                tool_name, tool_response
+            ));
 
             history.push(json!({
                 "role": "model",
@@ -146,13 +187,16 @@ pub async fn execute_task(agent: &Agent, task: &Task) -> Result<ExecutionResult>
                 "parts": [{"functionResponse": {"name": tool_name, "response": {"content": tool_response}}}]
             }));
         } else if let Some(text) = part.get("text") {
-            return Ok(ExecutionResult::Success {
-                comment: text.as_str().unwrap().to_string(),
-            });
+            let comment = text.as_str().unwrap().to_string();
+            let _ = append_log(&format!(
+                "Agent {} finished successfully: {}",
+                agent.id, comment
+            ));
+            return Ok(ExecutionResult::Success { comment });
         } else {
-            return Ok(ExecutionResult::Failure {
-                comment: "No tool call or text response from the model".to_string(),
-            });
+            let msg = "No tool call or text response from the model".to_string();
+            let _ = append_log(&format!("Agent {} failed: {}", agent.id, msg));
+            return Ok(ExecutionResult::Failure { comment: msg });
         }
     }
 }

--- a/src/tools/manage_file.rs
+++ b/src/tools/manage_file.rs
@@ -1,0 +1,44 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+
+use crate::agent::FunctionDeclaration;
+
+const DECL_JSON: &str = include_str!("../../tools/manage_file.json");
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid manage_file.json")
+}
+
+pub fn execute(args: &Value) -> Result<String> {
+    let filename = args["filename"]
+        .as_str()
+        .ok_or_else(|| anyhow!("filename missing"))?;
+    let mode = args["mode"].as_str().unwrap_or("read");
+    match mode {
+        "read" => {
+            let content = fs::read_to_string(filename)?;
+            Ok(content)
+        }
+        "write" => {
+            let content = args["content"]
+                .as_str()
+                .ok_or_else(|| anyhow!("content missing"))?;
+            fs::write(filename, content)?;
+            Ok(format!("Written to {filename}"))
+        }
+        "append" => {
+            let content = args["content"]
+                .as_str()
+                .ok_or_else(|| anyhow!("content missing"))?;
+            let mut file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(filename)?;
+            write!(file, "{}", content)?;
+            Ok(format!("Appended to {filename}"))
+        }
+        _ => Err(anyhow!("invalid mode")),
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -11,6 +11,7 @@ pub mod email;
 pub mod get_description;
 pub mod list_agents;
 pub mod list_tasks;
+pub mod manage_file;
 
 pub fn builtin_declaration(name: &str) -> Option<FunctionDeclaration> {
     match name {
@@ -22,6 +23,7 @@ pub fn builtin_declaration(name: &str) -> Option<FunctionDeclaration> {
         "list_tasks" => Some(list_tasks::declaration()),
         "list_agents" => Some(list_agents::declaration()),
         "get_description" => Some(get_description::declaration()),
+        "manage_file" => Some(manage_file::declaration()),
         _ => None,
     }
 }
@@ -36,6 +38,7 @@ pub fn execute_tool(name: &str, args: &Value) -> Result<String> {
         "list_tasks" => list_tasks::execute(args),
         "list_agents" => list_agents::execute(args),
         "get_description" => get_description::execute(args),
+        "manage_file" => manage_file::execute(args),
         _ => Err(anyhow::anyhow!("Unknown tool: {}", name)),
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -12,6 +12,7 @@ pub mod get_description;
 pub mod list_agents;
 pub mod list_tasks;
 pub mod manage_file;
+pub mod run_bash;
 
 pub fn builtin_declaration(name: &str) -> Option<FunctionDeclaration> {
     match name {
@@ -22,6 +23,7 @@ pub fn builtin_declaration(name: &str) -> Option<FunctionDeclaration> {
         "add_okr" => Some(add_okr::declaration()),
         "list_tasks" => Some(list_tasks::declaration()),
         "list_agents" => Some(list_agents::declaration()),
+        "run_bash" => Some(run_bash::declaration()),
         "get_description" => Some(get_description::declaration()),
         "manage_file" => Some(manage_file::declaration()),
         _ => None,
@@ -37,6 +39,7 @@ pub fn execute_tool(name: &str, args: &Value) -> Result<String> {
         "add_okr" => add_okr::execute(args),
         "list_tasks" => list_tasks::execute(args),
         "list_agents" => list_agents::execute(args),
+        "run_bash" => run_bash::execute(args),
         "get_description" => get_description::execute(args),
         "manage_file" => manage_file::execute(args),
         _ => Err(anyhow::anyhow!("Unknown tool: {}", name)),

--- a/src/tools/run_bash.rs
+++ b/src/tools/run_bash.rs
@@ -1,0 +1,28 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use std::process::Command;
+
+use crate::agent::FunctionDeclaration;
+
+const DECL_JSON: &str = include_str!("../../tools/run_bash.json");
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid run_bash.json")
+}
+
+pub fn execute(args: &Value) -> Result<String> {
+    let command = args["command"]
+        .as_str()
+        .ok_or_else(|| anyhow!("command missing"))?;
+
+    let output = Command::new("sh").arg("-c").arg(command).output()?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        Err(anyhow!(
+            "Command failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ))
+    }
+}

--- a/tests/cli_commands.rs
+++ b/tests/cli_commands.rs
@@ -18,20 +18,23 @@ fn with_temp_dir<F: FnOnce() -> T, T>(test: F) -> T {
 fn add_list_done_workflow() {
     with_temp_dir(|| {
         // Initialize board
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .arg("init")
             .assert()
             .success();
 
         // Add a task
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .args(["add", "--title", "Test task"])
             .assert()
             .success()
             .stdout(predicate::str::contains("Task added successfully"));
 
         // Verify list output contains the task
-        let out = Command::cargo_bin("taskter").unwrap()
+        let out = Command::cargo_bin("taskter")
+            .unwrap()
             .arg("list")
             .assert()
             .success()
@@ -42,14 +45,16 @@ fn add_list_done_workflow() {
         assert!(output.contains("Test task"));
 
         // Mark the task as done
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .args(["done", "1"])
             .assert()
             .success()
             .stdout(predicate::str::contains("marked as done"));
 
         // Inspect board file
-        let board: Value = serde_json::from_str(&fs::read_to_string(".taskter/board.json").unwrap()).unwrap();
+        let board: Value =
+            serde_json::from_str(&fs::read_to_string(".taskter/board.json").unwrap()).unwrap();
         assert_eq!(board["tasks"][0]["status"], "Done");
     });
 }
@@ -58,33 +63,50 @@ fn add_list_done_workflow() {
 fn add_agent_and_execute_task() {
     with_temp_dir(|| {
         // prepare board
-        Command::cargo_bin("taskter").unwrap().arg("init").assert().success();
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .arg("init")
+            .assert()
+            .success();
 
         // add a task
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .args(["add", "--title", "Send email"])
             .assert()
             .success();
 
         // add agent with builtin tool
-        Command::cargo_bin("taskter").unwrap()
-            .args(["add-agent", "--prompt", "email agent", "--tools", "email", "--model", "gpt-4o"])
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .args([
+                "add-agent",
+                "--prompt",
+                "email agent",
+                "--tools",
+                "email",
+                "--model",
+                "gpt-4o",
+            ])
             .assert()
             .success();
 
         // assign agent to task
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .args(["assign", "--task-id", "1", "--agent-id", "1"])
             .assert()
             .success();
 
         // execute the task
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .args(["execute", "--task-id", "1"])
             .assert()
             .success();
 
-        let board: Value = serde_json::from_str(&fs::read_to_string(".taskter/board.json").unwrap()).unwrap();
+        let board: Value =
+            serde_json::from_str(&fs::read_to_string(".taskter/board.json").unwrap()).unwrap();
         assert_eq!(board["tasks"][0]["status"], "Done");
     });
 }

--- a/tools/manage_file.json
+++ b/tools/manage_file.json
@@ -1,0 +1,13 @@
+{
+  "name": "manage_file",
+  "description": "Read, write or append to a text file in the current directory",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "filename": { "type": "string", "description": "File name" },
+      "mode": { "type": "string", "description": "Operation: read, write or append" },
+      "content": { "type": "string", "description": "Content for write or append" }
+    },
+    "required": ["filename", "mode"]
+  }
+}

--- a/tools/run_bash.json
+++ b/tools/run_bash.json
@@ -1,0 +1,11 @@
+{
+  "name": "run_bash",
+  "description": "Execute a bash command and return its output",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "command": { "type": "string", "description": "Shell command to execute" }
+    },
+    "required": ["command"]
+  }
+}


### PR DESCRIPTION
## Summary
- provide `manage_file` tool JSON definition
- implement `manage_file` tool for reading/writing text files
- register tool in builtin mapping
- document new builtin in README

## Testing
- `./scripts/precommit.sh`

------
https://chatgpt.com/codex/tasks/task_e_6879949560988320b07b23d2404b1aca