### PR TITLE
Add tests for agent JSON file management

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -157,7 +157,7 @@ pub async fn execute_task(agent: &Agent, task: &Task) -> Result<ExecutionResult>
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct FunctionDeclaration {
     pub name: String,
     pub description: Option<String>,
@@ -169,7 +169,7 @@ fn empty_params() -> Value {
     serde_json::json!({})
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Agent {
     pub id: usize,
     pub system_prompt: String,

--- a/tests/agent_file_ops.rs
+++ b/tests/agent_file_ops.rs
@@ -30,8 +30,18 @@ fn load_creates_empty_agents_file() {
 fn save_and_list_roundtrip() {
     with_temp_dir(|| {
         let agents = vec![
-            Agent { id: 1, system_prompt: "a".into(), tools: vec![], model: "m".into() },
-            Agent { id: 2, system_prompt: "b".into(), tools: vec![], model: "m".into() },
+            Agent {
+                id: 1,
+                system_prompt: "a".into(),
+                tools: vec![],
+                model: "m".into(),
+            },
+            Agent {
+                id: 2,
+                system_prompt: "b".into(),
+                tools: vec![],
+                model: "m".into(),
+            },
         ];
 
         agent::save_agents(&agents).expect("save failed");
@@ -47,8 +57,18 @@ fn save_and_list_roundtrip() {
 fn delete_removes_agent() {
     with_temp_dir(|| {
         let agents = vec![
-            Agent { id: 1, system_prompt: "a".into(), tools: vec![], model: "m".into() },
-            Agent { id: 2, system_prompt: "b".into(), tools: vec![], model: "m".into() },
+            Agent {
+                id: 1,
+                system_prompt: "a".into(),
+                tools: vec![],
+                model: "m".into(),
+            },
+            Agent {
+                id: 2,
+                system_prompt: "b".into(),
+                tools: vec![],
+                model: "m".into(),
+            },
         ];
 
         agent::save_agents(&agents).expect("save failed");

--- a/tests/agent_file_ops.rs
+++ b/tests/agent_file_ops.rs
@@ -1,0 +1,64 @@
+use std::fs;
+use taskter::agent::{self, Agent};
+
+fn with_temp_dir<F: FnOnce() -> T, T>(test: F) -> T {
+    let tmp = tempfile::tempdir().expect("failed to create temp dir");
+    let original_dir = std::env::current_dir().expect("cannot read current dir");
+    std::env::set_current_dir(tmp.path()).expect("cannot set current dir");
+
+    // Ensure workspace directory exists
+    fs::create_dir(".taskter").unwrap();
+
+    let result = test();
+
+    std::env::set_current_dir(original_dir).expect("cannot restore current dir");
+    result
+}
+
+#[test]
+fn load_creates_empty_agents_file() {
+    with_temp_dir(|| {
+        let agents = agent::load_agents().expect("cannot load agents");
+        assert!(agents.is_empty());
+
+        let content = fs::read_to_string(".taskter/agents.json").expect("cannot read file");
+        assert_eq!(content, "[]");
+    });
+}
+
+#[test]
+fn save_and_list_roundtrip() {
+    with_temp_dir(|| {
+        let agents = vec![
+            Agent { id: 1, system_prompt: "a".into(), tools: vec![], model: "m".into() },
+            Agent { id: 2, system_prompt: "b".into(), tools: vec![], model: "m".into() },
+        ];
+
+        agent::save_agents(&agents).expect("save failed");
+        let loaded = agent::load_agents().expect("load failed");
+        assert_eq!(loaded, agents);
+
+        let listed = agent::list_agents().expect("list failed");
+        assert_eq!(listed, agents);
+    });
+}
+
+#[test]
+fn delete_removes_agent() {
+    with_temp_dir(|| {
+        let agents = vec![
+            Agent { id: 1, system_prompt: "a".into(), tools: vec![], model: "m".into() },
+            Agent { id: 2, system_prompt: "b".into(), tools: vec![], model: "m".into() },
+        ];
+
+        agent::save_agents(&agents).expect("save failed");
+        agent::delete_agent(1).expect("delete failed");
+
+        let remaining = agent::load_agents().expect("load failed");
+        assert_eq!(remaining, vec![agents[1].clone()]);
+
+        let content = fs::read_to_string(".taskter/agents.json").expect("read failed");
+        let on_disk: Vec<Agent> = serde_json::from_str(&content).unwrap();
+        assert_eq!(on_disk, remaining);
+    });
+}

--- a/tests/cli_commands.rs
+++ b/tests/cli_commands.rs
@@ -18,20 +18,23 @@ fn with_temp_dir<F: FnOnce() -> T, T>(test: F) -> T {
 fn add_list_done_workflow() {
     with_temp_dir(|| {
         // Initialize board
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .arg("init")
             .assert()
             .success();
 
         // Add a task
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .args(["add", "--title", "Test task"])
             .assert()
             .success()
             .stdout(predicate::str::contains("Task added successfully"));
 
         // Verify list output contains the task
-        let out = Command::cargo_bin("taskter").unwrap()
+        let out = Command::cargo_bin("taskter")
+            .unwrap()
             .arg("list")
             .assert()
             .success()
@@ -42,14 +45,16 @@ fn add_list_done_workflow() {
         assert!(output.contains("Test task"));
 
         // Mark the task as done
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .args(["done", "1"])
             .assert()
             .success()
             .stdout(predicate::str::contains("marked as done"));
 
         // Inspect board file
-        let board: Value = serde_json::from_str(&fs::read_to_string(".taskter/board.json").unwrap()).unwrap();
+        let board: Value =
+            serde_json::from_str(&fs::read_to_string(".taskter/board.json").unwrap()).unwrap();
         assert_eq!(board["tasks"][0]["status"], "Done");
     });
 }
@@ -58,33 +63,50 @@ fn add_list_done_workflow() {
 fn add_agent_and_execute_task() {
     with_temp_dir(|| {
         // prepare board
-        Command::cargo_bin("taskter").unwrap().arg("init").assert().success();
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .arg("init")
+            .assert()
+            .success();
 
         // add a task
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .args(["add", "--title", "Send email"])
             .assert()
             .success();
 
         // add agent with builtin tool
-        Command::cargo_bin("taskter").unwrap()
-            .args(["add-agent", "--prompt", "email agent", "--tools", "email", "--model", "gpt-4o"])
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .args([
+                "add-agent",
+                "--prompt",
+                "email agent",
+                "--tools",
+                "email",
+                "--model",
+                "gpt-4o",
+            ])
             .assert()
             .success();
 
         // assign agent to task
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .args(["assign", "--task-id", "1", "--agent-id", "1"])
             .assert()
             .success();
 
         // execute the task
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .args(["execute", "--task-id", "1"])
             .assert()
             .success();
 
-        let board: Value = serde_json::from_str(&fs::read_to_string(".taskter/board.json").unwrap()).unwrap();
+        let board: Value =
+            serde_json::from_str(&fs::read_to_string(".taskter/board.json").unwrap()).unwrap();
         assert_eq!(board["tasks"][0]["status"], "Done");
     });
 }


### PR DESCRIPTION
## Summary
- derive `PartialEq` for Agent structs to simplify comparisons in tests
- add new integration tests covering agent JSON persistence

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687996f56250832092d3367e285924b4