### PR TITLE
Add run_python tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Taskter now supports LLM-based agents that can be assigned to tasks. These agent
   the name of a built-in tool. Built-ins live under the `tools/` directory of
   the repository. For example `email` resolves to `tools/send_email.json`.
   Other built-ins include `create_task`, `assign_agent`, `add_log`, `add_okr`,
-  `list_tasks`, `list_agents`, `get_description`, and `run_bash`.
+  `list_tasks`, `list_agents`, `get_description`, `run_bash`, and `run_python`.
 
 - **Assign an agent to a task:**
   ```bash

--- a/docs/src/agent_system.md
+++ b/docs/src/agent_system.md
@@ -21,6 +21,7 @@ Available built-in tools:
 - `list_agents`
 - `get_description`
 - `run_bash`
+- `run_python`
 - `send_email`
 
 ## Assigning an Agent to a Task

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -12,6 +12,7 @@ pub mod get_description;
 pub mod list_agents;
 pub mod list_tasks;
 pub mod run_bash;
+pub mod run_python;
 
 pub fn builtin_declaration(name: &str) -> Option<FunctionDeclaration> {
     match name {
@@ -23,6 +24,7 @@ pub fn builtin_declaration(name: &str) -> Option<FunctionDeclaration> {
         "list_tasks" => Some(list_tasks::declaration()),
         "list_agents" => Some(list_agents::declaration()),
         "run_bash" => Some(run_bash::declaration()),
+        "run_python" => Some(run_python::declaration()),
         "get_description" => Some(get_description::declaration()),
         _ => None,
     }
@@ -38,6 +40,7 @@ pub fn execute_tool(name: &str, args: &Value) -> Result<String> {
         "list_tasks" => list_tasks::execute(args),
         "list_agents" => list_agents::execute(args),
         "run_bash" => run_bash::execute(args),
+        "run_python" => run_python::execute(args),
         "get_description" => get_description::execute(args),
         _ => Err(anyhow::anyhow!("Unknown tool: {}", name)),
     }

--- a/src/tools/run_python.rs
+++ b/src/tools/run_python.rs
@@ -1,0 +1,28 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use std::process::Command;
+
+use crate::agent::FunctionDeclaration;
+
+const DECL_JSON: &str = include_str!("../../tools/run_python.json");
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid run_python.json")
+}
+
+pub fn execute(args: &Value) -> Result<String> {
+    let code = args["code"]
+        .as_str()
+        .ok_or_else(|| anyhow!("code missing"))?;
+
+    let output = Command::new("python3").arg("-c").arg(code).output()?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        Err(anyhow!(
+            "Python execution failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ))
+    }
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -150,3 +150,10 @@ async fn agent_execution_fails_without_tool() {
     // Then
     assert!(matches!(result, ExecutionResult::Failure { .. }));
 }
+
+#[test]
+fn run_python_tool_executes_code() {
+    let result = taskter::tools::execute_tool("run_python", &json!({ "code": "print(40 + 2)" }))
+        .expect("execution failed");
+    assert_eq!(result.trim(), "42");
+}

--- a/tools/run_python.json
+++ b/tools/run_python.json
@@ -1,0 +1,11 @@
+{
+  "name": "run_python",
+  "description": "Execute a Python script and return its output",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "code": { "type": "string", "description": "Python code to execute" }
+    },
+    "required": ["code"]
+  }
+}


### PR DESCRIPTION
## Summary
- add `run_python` builtin for executing Python code
- document the new builtin tool
- test `run_python` in integration tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687bb274c9c48320b39551ecf87f3b15