### PR TITLE
Add web search tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +232,21 @@ name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "chumsky"
@@ -760,6 +790,30 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1843,6 +1897,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "chrono",
  "clap",
  "crossterm",
  "lettre",
@@ -2258,6 +2313,41 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1854,6 +1854,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "urlencoding",
 ]
 
 [[package]]
@@ -2091,6 +2092,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.37.0", features = ["full"] }
 lettre = "0.11.17"
+urlencoding = "2.1.3"
 [features]
 tui = []
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = "1.0"
 tokio = { version = "1.37.0", features = ["full"] }
 lettre = "0.11.17"
 urlencoding = "2.1.3"
+chrono = { version = "0.4", features = ["serde"] }
 [features]
 tui = []
 [dev-dependencies]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 The Taskter Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT of OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Taskter
 
+[![Test](https://github.com/tomatyss/taskter/actions/workflows/test.yml/badge.svg)](https://github.com/tomatyss/taskter/actions/workflows/test.yml)
+[![Crates.io](https://img.shields.io/crates/v/taskter)](https://crates.io/crates/taskter)
+[![Documentation](https://img.shields.io/badge/docs-gh--pages-informational)](https://tomatyss.github.io/taskter/)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
 Taskter is a terminal Kanban board CLI tool built with Rust.
 
 > **Warning**
@@ -11,6 +16,71 @@ Taskter is a terminal Kanban board CLI tool built with Rust.
 - Project description
 - Operation logs
 - OKRs (Objectives and Key Results)
+
+## Quick Start
+
+This section provides a quick overview of how to get started with Taskter.
+
+### 1. Initialize the board
+
+First, navigate to your project's directory and initialize the Taskter board:
+
+```bash
+taskter init
+```
+
+This will create a `.taskter` directory to store all your tasks, agents, and project data.
+
+### 2. Create an agent
+
+Next, create an agent to help you with your tasks. For this example, we'll create a simple agent that can run bash commands:
+
+```bash
+taskter add-agent --prompt "You are a helpful assistant that can run bash commands." --tools "run_bash" --model "gemini-2.5-pro"
+```
+
+You can list all available agents using:
+
+```bash
+taskter show agents
+```
+
+### 3. Create a task
+
+Now, let's create a task for your agent to complete:
+
+```bash
+taskter add -t "List files in the current directory" -d "Use the ls -la command to list all files and folders in the current directory."
+```
+
+You can see all your tasks by running:
+
+```bash
+taskter list
+```
+
+### 4. Assign the task to an agent
+
+Assign the newly created task to your agent:
+
+```bash
+taskter assign --task-id 1 --agent-id 1
+```
+
+### 5. Execute the task
+
+Finally, execute the task:
+
+```bash
+taskter execute --task-id 1
+```
+
+The agent will now run the task. If it's successful, the task will be marked as "Done". You can view the board at any time using the interactive UI:
+
+```bash
+taskter board
+```
+
 
 ## Build and Installation
 
@@ -91,6 +161,10 @@ In the interactive board, you can use the following keys:
 - `n`: Create a new task
 - `u`: Edit the selected task
 - `d`: Delete the selected task
+- `L`: View project logs
+- `A`: List available agents
+- `O`: Show OKRs
+- `?`: Show available commands
 
 ### Manage tasks
 
@@ -161,7 +235,7 @@ Taskter now supports LLM-based agents that can be assigned to tasks. These agent
   the name of a built-in tool. Built-ins live under the `tools/` directory of
   the repository. For example `email` resolves to `tools/send_email.json`.
   Other built-ins include `create_task`, `assign_agent`, `add_log`, `add_okr`,
-  `list_tasks`, `list_agents`, `get_description`, and `web_search`.
+  `list_tasks`, `list_agents`, `get_description`, `run_bash`, `run_python`, and `web_search`.
 
 - **Assign an agent to a task:**
   ```bash
@@ -174,7 +248,7 @@ Taskter now supports LLM-based agents that can be assigned to tasks. These agent
   ```
 - **List available agents:**
   ```bash
-  taskter list-agents
+  taskter show agents
   ```
 - **Delete an agent:**
   ```bash
@@ -252,3 +326,11 @@ ln -s ../../scripts/precommit.sh .git/hooks/pre-commit
 Rendered documentation is available on GitHub Pages: <https://tomatyss.github.io/taskter/>.
 
 To contribute to the book, edit the Markdown files under `docs/src/` and open a pull request. The `Deploy Docs` workflow will rebuild the book and publish it automatically when changes land on `main`.
+
+## Contributing
+
+Contributions are welcome! Please open an issue or submit a pull request.
+
+## License
+
+This project is licensed under the MIT License. See the `LICENSE` file for details.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Taskter now supports LLM-based agents that can be assigned to tasks. These agent
   the name of a built-in tool. Built-ins live under the `tools/` directory of
   the repository. For example `email` resolves to `tools/send_email.json`.
   Other built-ins include `create_task`, `assign_agent`, `add_log`, `add_okr`,
-  `list_tasks`, `list_agents`, and `get_description`.
+  `list_tasks`, `list_agents`, `get_description`, and `web_search`.
 
 - **Assign an agent to a task:**
   ```bash

--- a/docs/src/agent_system.md
+++ b/docs/src/agent_system.md
@@ -1,3 +1,45 @@
 # Agent System
 
-Agents can be assigned to tasks to automate their execution using LLM-based tools. Refer to `taskter add-agent --help` for configuration options.
+Taskter supports LLM-based agents that can be assigned to tasks. These agents can execute tasks using a mocked Gemini API for tool-calling.
+
+## Creating an Agent
+
+You can create an agent using the `add-agent` subcommand. You need to provide a prompt, a list of tools, and a model.
+
+```bash
+taskter add-agent --prompt "You are a helpful assistant." --tools "email" "calendar" --model "gemini-pro"
+```
+
+The `--tools` option accepts either paths to JSON files describing a tool or the name of a built-in tool. Built-in tools are located in the `tools/` directory of the repository.
+
+Available built-in tools:
+- `create_task`
+- `assign_agent`
+- `add_log`
+- `add_okr`
+- `list_tasks`
+- `list_agents`
+- `get_description`
+- `run_bash`
+- `run_python`
+- `send_email`
+
+## Assigning an Agent to a Task
+
+Once you have created an agent, you can assign it to a task using the `assign` subcommand:
+
+```bash
+taskter assign --task-id 1 --agent-id 1
+```
+
+## Executing a Task
+
+To execute a task with an assigned agent, use the `execute` subcommand:
+
+```bash
+taskter execute --task-id 1
+```
+
+When a task is executed, the agent will attempt to perform the task. If successful, the task is marked as "Done". If it fails, the task is moved back to "To Do", unassigned, and a comment from the agent is added.
+
+In the interactive board (`taskter board`), tasks assigned to an agent will be marked with a `*`. You can view the assigned agent ID and any comments by selecting the task and pressing `Enter`.

--- a/docs/src/cli_usage.md
+++ b/docs/src/cli_usage.md
@@ -1,3 +1,67 @@
 # CLI Usage
 
 Taskter exposes multiple subcommands. Run `taskter --help` to see the available options. The README lists common workflows.
+
+## Quick Start
+
+This section provides a quick overview of how to get started with Taskter.
+
+### 1. Initialize the board
+
+First, navigate to your project's directory and initialize the Taskter board:
+
+```bash
+taskter init
+```
+
+This will create a `.taskter` directory to store all your tasks, agents, and project data.
+
+### 2. Create an agent
+
+Next, create an agent to help you with your tasks. For this example, we'll create a simple agent that can run bash commands:
+
+```bash
+taskter add-agent --prompt "You are a helpful assistant that can run bash commands." --tools "run_bash" --model "gemini-pro"
+```
+
+You can list all available agents using:
+
+```bash
+taskter show agents
+```
+
+### 3. Create a task
+
+Now, let's create a task for your agent to complete:
+
+```bash
+taskter add -t "List files in the current directory" -d "Use the ls -la command to list all files and folders in the current directory."
+```
+
+You can see all your tasks by running:
+
+```bash
+taskter list
+```
+
+### 4. Assign the task to an agent
+
+Assign the newly created task to your agent:
+
+```bash
+taskter assign --task-id 1 --agent-id 1
+```
+
+### 5. Execute the task
+
+Finally, execute the task:
+
+```bash
+taskter execute --task-id 1
+```
+
+The agent will now run the task. If it's successful, the task will be marked as "Done". You can view the board at any time using the interactive UI:
+
+```bash
+taskter board
+```

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -1,3 +1,35 @@
 # Contributing
 
-Documentation is built with [mdBook](https://rust-lang.github.io/mdBook/). Edit the files under `docs/src/` and open a pull request. The GitHub Actions workflow will publish the book automatically.
+Contributions are welcome! This guide will help you get started with setting up your development environment and submitting your changes.
+
+## Development Environment
+
+To contribute to Taskter, you'll need to have Rust and Cargo installed. If you haven't already, follow the instructions at [rust-lang.org](https://www.rust-lang.org/tools/install).
+
+Once you have Rust set up, clone the repository and navigate to the project directory:
+
+```bash
+git clone https://github.com/tomatyss/taskter.git
+cd taskter
+```
+
+## Pre-commit checks
+
+Before committing any changes, please run the pre-commit script to ensure your code is formatted, linted, and passes all tests:
+
+```bash
+./scripts/precommit.sh
+```
+
+You can also set this up as a pre-commit hook to run automatically:
+
+```bash
+ln -s ../../scripts/precommit.sh .git/hooks/pre-commit
+```
+
+## Documentation
+
+The documentation is built with [mdBook](https://rust-lang.github.io/mdBook/). To contribute to the docs, edit the Markdown files under the `docs/src/` directory.
+
+When you're ready, open a pull request with your changes. The GitHub Actions workflow will automatically build and publish the book when your changes are merged into the `main` branch.
+

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -1,3 +1,49 @@
 # Installation
 
-Follow the instructions in the repository README to build Taskter from source or use Docker.
+You can install Taskter either by building from source or using Docker.
+
+## Build from Source
+
+To build Taskter from source, you need to have Rust and Cargo installed.
+
+1.  Clone the repository:
+    ```bash
+    git clone https://github.com/tomatyss/taskter.git
+    cd taskter
+    ```
+
+2.  Build the project:
+    ```bash
+    cargo build --release
+    ```
+    The executable will be located at `target/release/taskter`.
+
+3.  Install the executable:
+    You can make `taskter` available system-wide by copying it to a directory in your system's `PATH`. For example, on macOS or Linux:
+    ```bash
+    sudo cp target/release/taskter /usr/local/bin/taskter
+    ```
+    Alternatively, you can use `cargo install`:
+    ```bash
+    cargo install --path .
+    ```
+    This will install the `taskter` executable in your Cargo bin directory (`~/.cargo/bin/`), which should be in your `PATH`.
+
+## Docker
+
+If you prefer to use Docker, you can build and run Taskter without installing Rust locally.
+
+1.  Build the Docker image:
+    ```bash
+    docker build -t taskter .
+    ```
+
+2.  Run the application:
+    ```bash
+    docker compose run --rm taskter --help
+    ```
+    If you plan to use the Gemini integration for agents, you'll need to pass your API key as an environment variable:
+    ```bash
+    GEMINI_API_KEY=<your_key> docker compose run --rm taskter --help
+    ```
+

--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -1,3 +1,15 @@
 # Overview
 
-Taskter is a terminal-based Kanban board written in Rust. This book provides an overview of its features and how to use them.
+Taskter is a powerful, terminal-based Kanban board designed for developers, project managers, and anyone who prefers to manage their tasks directly from the command line. Built with Rust, Taskter is a lightweight and efficient tool that helps you keep track of your projects without leaving the terminal.
+
+## Key Features
+
+- **Kanban Board**: Visualize your workflow with ToDo, In-Progress, and Done columns.
+- **Task Management**: Add, edit, delete, and manage tasks with simple commands.
+- **Agent System**: Automate tasks using LLM-based agents with tool-calling capabilities.
+- **Project Tracking**: Keep track of your project's description, objectives, and key results (OKRs).
+- **Operation Logs**: Maintain a log of all operations performed on the board.
+- **Interactive TUI**: A user-friendly terminal interface for easy navigation and task management.
+
+This book serves as the official documentation for Taskter, providing a comprehensive guide to its features and usage. Whether you're a new user or a seasoned developer, this guide will help you get the most out of Taskter.
+

--- a/docs/src/tui_guide.md
+++ b/docs/src/tui_guide.md
@@ -1,3 +1,29 @@
 # TUI Guide
 
-Launch the interactive board with `taskter board`. Use the keyboard shortcuts displayed in the help menu to navigate between tasks and columns.
+Taskter's interactive Terminal User Interface (TUI) provides a visual way to manage your Kanban board. To launch it, run:
+
+```bash
+taskter board
+```
+
+## Keybindings
+
+The TUI is controlled with keyboard shortcuts. Here is a list of the available keybindings:
+
+| Key(s)              | Action                               |
+| ------------------- | ------------------------------------ |
+| `q`                 | Quit the application                 |
+| `←` / `→` or `Tab`  | Navigate between columns             |
+| `↑` / `↓`           | Navigate between tasks in a column   |
+| `h` / `l`           | Move a selected task to the next or previous column |
+| `n`                 | Create a new task                    |
+| `u`                 | Edit the selected task               |
+| `d`                 | Delete the selected task             |
+| `a`                 | Assign an agent to the selected task |
+| `c`                 | Add a comment to the selected task   |
+| `L`                 | View project logs                    |
+| `A`                 | List available agents                |
+| `O`                 | Show project OKRs                    |
+| `?`                 | Show available commands              |
+
+When a task is selected, you can press `Enter` to view its details, including the full description, any comments, and the assigned agent ID.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,10 +1,13 @@
 use crate::store::Task;
 use crate::tools;
 use anyhow::Result;
+use chrono::Local;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::fs;
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::Path;
 
 #[derive(Debug, PartialEq)]
@@ -13,8 +16,22 @@ pub enum ExecutionResult {
     Failure { comment: String },
 }
 
+fn append_log(message: &str) -> Result<()> {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(".taskter/logs.log")?;
+    let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S");
+    writeln!(file, "[{timestamp}] {message}")?;
+    Ok(())
+}
+
 pub async fn execute_task(agent: &Agent, task: &Task) -> Result<ExecutionResult> {
     let client = Client::new();
+    let _ = append_log(&format!(
+        "Agent {} executing task {}: {}",
+        agent.id, task.id, task.title
+    ));
     // Obtain the API key if it is available.  In a testing or offline environment the
     // variable is typically missing.  Rather than crashing the whole process with
     // `expect`, we fall back to a mocked implementation that evaluates the task purely
@@ -38,13 +55,18 @@ pub async fn execute_task(agent: &Agent, task: &Task) -> Result<ExecutionResult>
     // available, otherwise fail.
     if api_key.is_none() {
         if has_send_email_tool {
-            return Ok(ExecutionResult::Success {
-                comment: "No API key found. Task considered complete.".to_string(),
-            });
+            let _ = append_log("Executing without API key - success via built-in tool");
+            let msg = "No API key found. Task considered complete.".to_string();
+            let _ = append_log(&format!(
+                "Agent {} finished successfully: {}",
+                agent.id, msg
+            ));
+            return Ok(ExecutionResult::Success { comment: msg });
         } else {
-            return Ok(ExecutionResult::Failure {
-                comment: "Required tool not available.".to_string(),
-            });
+            let _ = append_log("Executing without API key - required tool missing");
+            let msg = "Required tool not available.".to_string();
+            let _ = append_log(&format!("Agent {} failed: {}", agent.id, msg));
+            return Ok(ExecutionResult::Failure { comment: msg });
         }
     }
 
@@ -87,14 +109,18 @@ pub async fn execute_task(agent: &Agent, task: &Task) -> Result<ExecutionResult>
         {
             Ok(resp) => resp,
             Err(_) => {
+                let _ = append_log("API request failed; falling back to local simulation");
                 return Ok(if has_send_email_tool {
-                    ExecutionResult::Success {
-                        comment: "Tool available. Task considered complete.".to_string(),
-                    }
+                    let msg = "Tool available. Task considered complete.".to_string();
+                    let _ = append_log(&format!(
+                        "Agent {} finished successfully: {}",
+                        agent.id, msg
+                    ));
+                    ExecutionResult::Success { comment: msg }
                 } else {
-                    ExecutionResult::Failure {
-                        comment: "Required tool not available.".to_string(),
-                    }
+                    let msg = "Required tool not available.".to_string();
+                    let _ = append_log(&format!("Agent {} failed: {}", agent.id, msg));
+                    ExecutionResult::Failure { comment: msg }
                 });
             }
         };
@@ -103,28 +129,37 @@ pub async fn execute_task(agent: &Agent, task: &Task) -> Result<ExecutionResult>
             // When the API rejects the request (for example due to an invalid key)
             // we once again fall back to the local simulation.  This keeps normal
             // development and CI runs independent from external services.
+            let _ = append_log("API returned error status; falling back to local simulation");
             return Ok(if has_send_email_tool {
-                ExecutionResult::Success {
-                    comment: "Tool available. Task considered complete.".to_string(),
-                }
+                let msg = "Tool available. Task considered complete.".to_string();
+                let _ = append_log(&format!(
+                    "Agent {} finished successfully: {}",
+                    agent.id, msg
+                ));
+                ExecutionResult::Success { comment: msg }
             } else {
-                ExecutionResult::Failure {
-                    comment: "Required tool not available.".to_string(),
-                }
+                let msg = "Required tool not available.".to_string();
+                let _ = append_log(&format!("Agent {} failed: {}", agent.id, msg));
+                ExecutionResult::Failure { comment: msg }
             });
         }
 
         let response_json: Value = match response.json().await {
             Ok(json) => json,
             Err(_) => {
+                let _ =
+                    append_log("Failed to parse API response; falling back to local simulation");
                 return Ok(if has_send_email_tool {
-                    ExecutionResult::Success {
-                        comment: "Tool available. Task considered complete.".to_string(),
-                    }
+                    let msg = "Tool available. Task considered complete.".to_string();
+                    let _ = append_log(&format!(
+                        "Agent {} finished successfully: {}",
+                        agent.id, msg
+                    ));
+                    ExecutionResult::Success { comment: msg }
                 } else {
-                    ExecutionResult::Failure {
-                        comment: "Required tool not available.".to_string(),
-                    }
+                    let msg = "Required tool not available.".to_string();
+                    let _ = append_log(&format!("Agent {} failed: {}", agent.id, msg));
+                    ExecutionResult::Failure { comment: msg }
                 });
             }
         };
@@ -135,7 +170,15 @@ pub async fn execute_task(agent: &Agent, task: &Task) -> Result<ExecutionResult>
         if let Some(function_call) = part.get("functionCall") {
             let tool_name = function_call["name"].as_str().unwrap();
             let args = &function_call["args"];
+            let _ = append_log(&format!(
+                "Agent {} calling tool {} with args {}",
+                agent.id, tool_name, args
+            ));
             let tool_response = tools::execute_tool(tool_name, args)?;
+            let _ = append_log(&format!(
+                "Tool {} responded with {}",
+                tool_name, tool_response
+            ));
 
             history.push(json!({
                 "role": "model",
@@ -146,13 +189,16 @@ pub async fn execute_task(agent: &Agent, task: &Task) -> Result<ExecutionResult>
                 "parts": [{"functionResponse": {"name": tool_name, "response": {"content": tool_response}}}]
             }));
         } else if let Some(text) = part.get("text") {
-            return Ok(ExecutionResult::Success {
-                comment: text.as_str().unwrap().to_string(),
-            });
+            let comment = text.as_str().unwrap().to_string();
+            let _ = append_log(&format!(
+                "Agent {} finished successfully: {}",
+                agent.id, comment
+            ));
+            return Ok(ExecutionResult::Success { comment });
         } else {
-            return Ok(ExecutionResult::Failure {
-                comment: "No tool call or text response from the model".to_string(),
-            });
+            let msg = "No tool call or text response from the model".to_string();
+            let _ = append_log(&format!("Agent {} failed: {}", agent.id, msg));
+            return Ok(ExecutionResult::Failure { comment: msg });
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use chrono::Local;
 use clap::{Parser, Subcommand};
 use std::fs;
 use std::io::Write;
@@ -98,9 +99,6 @@ enum Commands {
         #[arg(short, long)]
         agent_id: usize,
     },
-    /// Lists all agents
-    #[command(name = "list-agents")]
-    ListAgents,
     /// Deletes an agent by id
     #[command(name = "delete-agent")]
     DeleteAgent {
@@ -118,6 +116,8 @@ enum ShowCommands {
     Okrs,
     /// Shows the operation logs
     Logs,
+    /// Lists all agents
+    Agents,
 }
 
 #[tokio::main]
@@ -198,6 +198,12 @@ async fn main() -> anyhow::Result<()> {
                 let logs = fs::read_to_string(".taskter/logs.log")?;
                 println!("{logs}");
             }
+            ShowCommands::Agents => {
+                let agents = agent::list_agents()?;
+                for a in agents {
+                    println!("{}: {}", a.id, a.system_prompt);
+                }
+            }
         },
         Commands::AddOkr {
             objective,
@@ -223,7 +229,8 @@ async fn main() -> anyhow::Result<()> {
                 .create(true)
                 .append(true)
                 .open(".taskter/logs.log")?;
-            writeln!(file, "{message}")?;
+            let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S");
+            writeln!(file, "[{timestamp}] {message}")?;
             println!("Log added successfully.");
         }
         Commands::Board => {
@@ -308,12 +315,6 @@ async fn main() -> anyhow::Result<()> {
                 println!("Agent {agent_id} assigned to task {task_id}.");
             } else {
                 println!("Task with id {task_id} not found.");
-            }
-        }
-        Commands::ListAgents => {
-            let agents = agent::list_agents()?;
-            for a in agents {
-                println!("{}: {}", a.id, a.system_prompt);
             }
         }
         Commands::DeleteAgent { agent_id } => {

--- a/src/tools/add_log.rs
+++ b/src/tools/add_log.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, Result};
+use chrono::Local;
 use serde_json::Value;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -19,6 +20,7 @@ pub fn execute(args: &Value) -> Result<String> {
         .create(true)
         .append(true)
         .open(".taskter/logs.log")?;
-    writeln!(file, "{message}")?;
+    let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S");
+    writeln!(file, "[{timestamp}] {message}")?;
     Ok("Log entry added".to_string())
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -11,6 +11,8 @@ pub mod email;
 pub mod get_description;
 pub mod list_agents;
 pub mod list_tasks;
+pub mod run_bash;
+pub mod run_python;
 pub mod web_search;
 
 pub fn builtin_declaration(name: &str) -> Option<FunctionDeclaration> {
@@ -22,6 +24,8 @@ pub fn builtin_declaration(name: &str) -> Option<FunctionDeclaration> {
         "add_okr" => Some(add_okr::declaration()),
         "list_tasks" => Some(list_tasks::declaration()),
         "list_agents" => Some(list_agents::declaration()),
+        "run_bash" => Some(run_bash::declaration()),
+        "run_python" => Some(run_python::declaration()),
         "get_description" => Some(get_description::declaration()),
         "web_search" => Some(web_search::declaration()),
         _ => None,
@@ -37,6 +41,8 @@ pub fn execute_tool(name: &str, args: &Value) -> Result<String> {
         "add_okr" => add_okr::execute(args),
         "list_tasks" => list_tasks::execute(args),
         "list_agents" => list_agents::execute(args),
+        "run_bash" => run_bash::execute(args),
+        "run_python" => run_python::execute(args),
         "get_description" => get_description::execute(args),
         "web_search" => web_search::execute(args),
         _ => Err(anyhow::anyhow!("Unknown tool: {}", name)),

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -11,6 +11,7 @@ pub mod email;
 pub mod get_description;
 pub mod list_agents;
 pub mod list_tasks;
+pub mod web_search;
 
 pub fn builtin_declaration(name: &str) -> Option<FunctionDeclaration> {
     match name {
@@ -22,6 +23,7 @@ pub fn builtin_declaration(name: &str) -> Option<FunctionDeclaration> {
         "list_tasks" => Some(list_tasks::declaration()),
         "list_agents" => Some(list_agents::declaration()),
         "get_description" => Some(get_description::declaration()),
+        "web_search" => Some(web_search::declaration()),
         _ => None,
     }
 }
@@ -36,6 +38,7 @@ pub fn execute_tool(name: &str, args: &Value) -> Result<String> {
         "list_tasks" => list_tasks::execute(args),
         "list_agents" => list_agents::execute(args),
         "get_description" => get_description::execute(args),
+        "web_search" => web_search::execute(args),
         _ => Err(anyhow::anyhow!("Unknown tool: {}", name)),
     }
 }

--- a/src/tools/run_bash.rs
+++ b/src/tools/run_bash.rs
@@ -1,0 +1,28 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use std::process::Command;
+
+use crate::agent::FunctionDeclaration;
+
+const DECL_JSON: &str = include_str!("../../tools/run_bash.json");
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid run_bash.json")
+}
+
+pub fn execute(args: &Value) -> Result<String> {
+    let command = args["command"]
+        .as_str()
+        .ok_or_else(|| anyhow!("command missing"))?;
+
+    let output = Command::new("sh").arg("-c").arg(command).output()?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        Err(anyhow!(
+            "Command failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ))
+    }
+}

--- a/src/tools/run_python.rs
+++ b/src/tools/run_python.rs
@@ -1,0 +1,28 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use std::process::Command;
+
+use crate::agent::FunctionDeclaration;
+
+const DECL_JSON: &str = include_str!("../../tools/run_python.json");
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid run_python.json")
+}
+
+pub fn execute(args: &Value) -> Result<String> {
+    let code = args["code"]
+        .as_str()
+        .ok_or_else(|| anyhow!("code missing"))?;
+
+    let output = Command::new("python3").arg("-c").arg(code).output()?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        Err(anyhow!(
+            "Python execution failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ))
+    }
+}

--- a/src/tools/web_search.rs
+++ b/src/tools/web_search.rs
@@ -1,0 +1,31 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+
+use crate::agent::FunctionDeclaration;
+
+const DECL_JSON: &str = include_str!("../../tools/web_search.json");
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid web_search.json")
+}
+
+pub fn execute(args: &Value) -> Result<String> {
+    let query = args["query"]
+        .as_str()
+        .ok_or_else(|| anyhow!("query missing"))?;
+
+    let encoded = urlencoding::encode(query);
+    let url = format!(
+        "https://duckduckgo.com/?q={}&format=json&no_redirect=1&no_html=1",
+        encoded
+    );
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+
+    match rt.block_on(async { reqwest::get(&url).await?.text().await }) {
+        Ok(text) => Ok(text),
+        Err(e) => Ok(format!("Failed to perform search: {e}")),
+    }
+}

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,5 +1,5 @@
 use crate::agent::{self, Agent};
-use crate::store::{self, Board, Task, TaskStatus};
+use crate::store::{self, Board, Okr, Task, TaskStatus};
 use crossterm::{
     event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
     execute,
@@ -11,6 +11,7 @@ use ratatui::{
     widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
 };
 use std::io;
+use std::sync::{Arc, Mutex};
 
 enum View {
     Board,
@@ -19,10 +20,14 @@ enum View {
     AddComment,
     AddTask,
     UpdateTask,
+    Logs,
+    Agents,
+    Okrs,
+    Commands,
 }
 
 struct App {
-    board: Board,
+    board: Arc<Mutex<Board>>,
     agents: Vec<Agent>,
     selected_column: usize,
     selected_task: [ListState; 3],
@@ -32,12 +37,14 @@ struct App {
     new_task_title: String,
     new_task_description: String,
     editing_description: bool,
+    logs: String,
+    okrs: Vec<Okr>,
 }
 
 impl App {
     fn new(board: Board, agents: Vec<Agent>) -> Self {
         let mut app = App {
-            board,
+            board: Arc::new(Mutex::new(board)),
             agents,
             selected_column: 0,
             selected_task: [
@@ -51,6 +58,8 @@ impl App {
             new_task_title: String::new(),
             new_task_description: String::new(),
             editing_description: false,
+            logs: std::fs::read_to_string(".taskter/logs.log").unwrap_or_default(),
+            okrs: store::load_okrs().unwrap_or_default(),
         };
         app.selected_task[0].select(Some(0));
         app
@@ -58,10 +67,23 @@ impl App {
 
     fn next_column(&mut self) {
         self.selected_column = (self.selected_column + 1) % 3;
+        self.ensure_selected_task();
     }
 
     fn prev_column(&mut self) {
         self.selected_column = (self.selected_column + 2) % 3;
+        self.ensure_selected_task();
+    }
+
+    fn ensure_selected_task(&mut self) {
+        let tasks = self.tasks_in_current_column();
+        if !tasks.is_empty()
+            && self.selected_task[self.selected_column]
+                .selected()
+                .is_none()
+        {
+            self.selected_task[self.selected_column].select(Some(0));
+        }
     }
 
     fn next_task(&mut self) {
@@ -88,16 +110,19 @@ impl App {
         self.selected_task[self.selected_column].select(Some(i));
     }
 
-    fn tasks_in_current_column(&self) -> Vec<&Task> {
+    fn tasks_in_current_column(&self) -> Vec<Task> {
         let status = match self.selected_column {
             0 => TaskStatus::ToDo,
             1 => TaskStatus::InProgress,
             _ => TaskStatus::Done,
         };
         self.board
+            .lock()
+            .unwrap()
             .tasks
             .iter()
             .filter(|t| t.status == status)
+            .cloned()
             .collect()
     }
 
@@ -119,7 +144,14 @@ impl App {
             };
 
         if let Some(task_id) = task_id_to_move {
-            if let Some(task) = self.board.tasks.iter_mut().find(|t| t.id == task_id) {
+            if let Some(task) = self
+                .board
+                .lock()
+                .unwrap()
+                .tasks
+                .iter_mut()
+                .find(|t| t.id == task_id)
+            {
                 let current_status_index = task.status.clone() as usize;
                 let next_status_index = (current_status_index as i8 + direction + 3) % 3;
                 task.status = match next_status_index {
@@ -131,7 +163,7 @@ impl App {
         }
     }
 
-    fn get_selected_task(&self) -> Option<&Task> {
+    fn get_selected_task(&self) -> Option<Task> {
         self.selected_task[self.selected_column]
             .selected()
             .and_then(|selected_index| {
@@ -176,7 +208,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
             match app.current_view {
                 View::Board => match key.code {
                     KeyCode::Char('q') => {
-                        store::save_board(&app.board).unwrap();
+                        store::save_board(&app.board.lock().unwrap()).unwrap();
                         return Ok(());
                     }
                     KeyCode::Right | KeyCode::Tab => app.next_column(),
@@ -209,7 +241,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                         app.current_view = View::AddTask;
                     }
                     KeyCode::Char('u') => {
-                        if let Some(task) = app.get_selected_task().cloned() {
+                        if let Some(task) = app.get_selected_task() {
                             app.new_task_title = task.title;
                             app.new_task_description = task.description.unwrap_or_default();
                             app.editing_description = false;
@@ -218,15 +250,30 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                     }
                     KeyCode::Char('d') => {
                         if let Some(task_id) = app.get_selected_task().map(|t| t.id) {
-                            app.board.tasks.retain(|t| t.id != task_id);
+                            app.board.lock().unwrap().tasks.retain(|t| t.id != task_id);
                             let tasks = app.tasks_in_current_column();
                             if !tasks.is_empty() {
                                 app.selected_task[app.selected_column].select(Some(0));
                             } else {
                                 app.selected_task[app.selected_column].select(None);
                             }
-                            store::save_board(&app.board).unwrap();
+                            store::save_board(&app.board.lock().unwrap()).unwrap();
                         }
+                    }
+                    KeyCode::Char('L') => {
+                        app.logs = std::fs::read_to_string(".taskter/logs.log").unwrap_or_default();
+                        app.current_view = View::Logs;
+                    }
+                    KeyCode::Char('A') => {
+                        app.agents = crate::agent::load_agents().unwrap_or_default();
+                        app.current_view = View::Agents;
+                    }
+                    KeyCode::Char('O') => {
+                        app.okrs = store::load_okrs().unwrap_or_default();
+                        app.current_view = View::Okrs;
+                    }
+                    KeyCode::Char('?') => {
+                        app.current_view = View::Commands;
                     }
                     _ => {}
                 },
@@ -257,57 +304,48 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                     KeyCode::Enter => {
                         if let Some(selected_agent_index) = app.agent_list_state.selected() {
                             if let Some(agent) = app.agents.get(selected_agent_index).cloned() {
-                                if let Some(task_id) = app.get_selected_task().map(|t| t.id) {
-                                    if let Some(task) =
-                                        app.board.tasks.iter_mut().find(|t| t.id == task_id)
+                                if let Some(task) = app.get_selected_task() {
+                                    let mut board = app.board.lock().unwrap();
+                                    if let Some(task_to_update) =
+                                        board.tasks.iter_mut().find(|t| t.id == task.id)
                                     {
-                                        task.agent_id = Some(agent.id);
-                                        // `execute_task` is asynchronous. We are inside the synchronous
-                                        // `run_app` loop which itself is executed from an async Tokio
-                                        // runtime (the `#[tokio::main]` in `main.rs`).  We therefore
-                                        // leverage the currently-running runtime handle to synchronously
-                                        // wait on the future. Using `Handle::current().block_on(...)` keeps
-                                        // the API here synchronous without spinning up a brand-new runtime
-                                        // each time.
-
-                                        // Calling `Handle::current().block_on(...)` inside an already
-                                        // running Tokio runtime panics ("Cannot start a runtime from
-                                        // within a runtime").  To remain in the synchronous context of
-                                        // the TUI while still awaiting the async `execute_task` call we
-                                        // off-load the blocking operation to Tokio's *blocking* thread
-                                        // pool via `block_in_place`.  Once on the dedicated blocking
-                                        // thread we spin up a lightweight *current-thread* runtime just
-                                        // for the duration of the task execution.
-                                        match tokio::task::block_in_place(|| {
-                                            tokio::runtime::Builder::new_current_thread()
-                                                .enable_all()
-                                                .build()
-                                                .unwrap()
-                                                .block_on(agent::execute_task(&agent, task))
-                                        }) {
-                                            Ok(result) => match result {
-                                                agent::ExecutionResult::Success { comment } => {
-                                                    task.status = store::TaskStatus::Done;
-                                                    task.comment = Some(comment);
-                                                }
-                                                agent::ExecutionResult::Failure { comment } => {
+                                        task_to_update.agent_id = Some(agent.id);
+                                    }
+                                    let agent_clone = agent.clone();
+                                    let task_clone = task.clone();
+                                    let board_clone = Arc::clone(&app.board);
+                                    tokio::spawn(async move {
+                                        let result =
+                                            agent::execute_task(&agent_clone, &task_clone).await;
+                                        let mut board = board_clone.lock().unwrap();
+                                        if let Some(task) =
+                                            board.tasks.iter_mut().find(|t| t.id == task_clone.id)
+                                        {
+                                            match result {
+                                                Ok(result) => match result {
+                                                    agent::ExecutionResult::Success { comment } => {
+                                                        task.status = store::TaskStatus::Done;
+                                                        task.comment = Some(comment);
+                                                    }
+                                                    agent::ExecutionResult::Failure { comment } => {
+                                                        task.status = store::TaskStatus::ToDo;
+                                                        task.comment = Some(comment);
+                                                        task.agent_id = None;
+                                                    }
+                                                },
+                                                Err(_) => {
                                                     task.status = store::TaskStatus::ToDo;
-                                                    task.comment = Some(comment);
+                                                    task.comment =
+                                                        Some("Failed to execute task.".to_string());
                                                     task.agent_id = None;
                                                 }
-                                            },
-                                            Err(_) => {
-                                                task.status = store::TaskStatus::ToDo;
-                                                task.comment =
-                                                    Some("Failed to execute task.".to_string());
-                                                task.agent_id = None;
                                             }
                                         }
-                                    }
+                                        store::save_board(&board).unwrap();
+                                    });
                                 }
                             }
                         }
-                        store::save_board(&app.board).unwrap();
                         app.current_view = View::Board;
                     }
                     _ => {}
@@ -318,11 +356,17 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                     }
                     KeyCode::Enter => {
                         if let Some(task_id) = app.get_selected_task().map(|t| t.id) {
-                            if let Some(task) = app.board.tasks.iter_mut().find(|t| t.id == task_id)
+                            if let Some(task) = app
+                                .board
+                                .lock()
+                                .unwrap()
+                                .tasks
+                                .iter_mut()
+                                .find(|t| t.id == task_id)
                             {
                                 task.comment = Some(app.comment_input.clone());
                             }
-                            store::save_board(&app.board).unwrap();
+                            store::save_board(&app.board.lock().unwrap()).unwrap();
                         }
                         app.current_view = View::Board;
                     }
@@ -351,7 +395,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                     }
                     KeyCode::Enter => {
                         if app.editing_description {
-                            let new_id = app.board.tasks.len() + 1;
+                            let new_id = app.board.lock().unwrap().tasks.len() + 1;
                             let task = Task {
                                 id: new_id,
                                 title: app.new_task_title.clone(),
@@ -364,8 +408,8 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                                 agent_id: None,
                                 comment: None,
                             };
-                            app.board.tasks.push(task);
-                            store::save_board(&app.board).unwrap();
+                            app.board.lock().unwrap().tasks.push(task);
+                            store::save_board(&app.board.lock().unwrap()).unwrap();
                             app.current_view = View::Board;
                             app.editing_description = false;
                         } else {
@@ -396,8 +440,13 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                     KeyCode::Enter => {
                         if app.editing_description {
                             if let Some(task_id) = app.get_selected_task().map(|t| t.id) {
-                                if let Some(task) =
-                                    app.board.tasks.iter_mut().find(|t| t.id == task_id)
+                                if let Some(task) = app
+                                    .board
+                                    .lock()
+                                    .unwrap()
+                                    .tasks
+                                    .iter_mut()
+                                    .find(|t| t.id == task_id)
                                 {
                                     task.title = app.new_task_title.clone();
                                     task.description = if app.new_task_description.is_empty() {
@@ -405,8 +454,8 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                                     } else {
                                         Some(app.new_task_description.clone())
                                     };
-                                    store::save_board(&app.board).unwrap();
                                 }
+                                store::save_board(&app.board.lock().unwrap()).unwrap();
                             }
                             app.current_view = View::Board;
                             app.editing_description = false;
@@ -417,6 +466,12 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                     KeyCode::Esc => {
                         app.current_view = View::Board;
                         app.editing_description = false;
+                    }
+                    _ => {}
+                },
+                View::Logs | View::Agents | View::Okrs | View::Commands => match key.code {
+                    KeyCode::Char('q') | KeyCode::Esc | KeyCode::Char('?') => {
+                        app.current_view = View::Board;
                     }
                     _ => {}
                 },
@@ -433,6 +488,10 @@ fn ui(f: &mut Frame, app: &mut App) {
         View::AddComment => render_add_comment(f, app),
         View::AddTask => render_add_task(f, app),
         View::UpdateTask => render_update_task(f, app),
+        View::Logs => render_logs(f, app),
+        View::Agents => render_agents_list(f, app),
+        View::Okrs => render_okrs(f, app),
+        View::Commands => render_commands(f),
         _ => {}
     }
 }
@@ -456,6 +515,8 @@ fn render_board(f: &mut Frame, app: &mut App) {
     {
         let tasks: Vec<ListItem> = app
             .board
+            .lock()
+            .unwrap()
             .tasks
             .iter()
             .filter(|t| t.status == *status)
@@ -610,6 +671,73 @@ fn render_update_task(f: &mut Frame, app: &mut App) {
     .block(block)
     .wrap(Wrap { trim: true });
     let area = centered_rect(60, 15, f.area());
+    f.render_widget(Clear, area);
+    f.render_widget(paragraph, area);
+}
+
+fn render_logs(f: &mut Frame, app: &mut App) {
+    let block = Block::default().title("Logs").borders(Borders::ALL);
+    let paragraph = Paragraph::new(app.logs.as_str())
+        .block(block)
+        .wrap(Wrap { trim: true });
+    let area = centered_rect(60, 50, f.area());
+    f.render_widget(Clear, area);
+    f.render_widget(paragraph, area);
+}
+
+fn render_agents_list(f: &mut Frame, app: &mut App) {
+    let items: Vec<ListItem> = app
+        .agents
+        .iter()
+        .map(|a| ListItem::new(format!("{}: {}", a.id, a.system_prompt)))
+        .collect();
+    let list = List::new(items).block(Block::default().title("Agents").borders(Borders::ALL));
+    let area = centered_rect(60, 25, f.area());
+    f.render_widget(Clear, area);
+    f.render_widget(list, area);
+}
+
+fn render_okrs(f: &mut Frame, app: &mut App) {
+    let mut lines = Vec::new();
+    for okr in &app.okrs {
+        lines.push(Line::from(Span::styled(
+            &okr.objective,
+            Style::default().add_modifier(Modifier::BOLD),
+        )));
+        for kr in &okr.key_results {
+            lines.push(Line::from(format!(
+                " - {} ({:.0}%)",
+                kr.name,
+                kr.progress * 100.0
+            )));
+        }
+        lines.push(Line::raw(""));
+    }
+    let block = Block::default().title("OKRs").borders(Borders::ALL);
+    let paragraph = Paragraph::new(lines).block(block).wrap(Wrap { trim: true });
+    let area = centered_rect(60, 50, f.area());
+    f.render_widget(Clear, area);
+    f.render_widget(paragraph, area);
+}
+
+fn render_commands(f: &mut Frame) {
+    let lines = vec![
+        Line::from("q - Quit"),
+        Line::from("←/→ or Tab - Switch columns"),
+        Line::from("↑/↓ - Navigate tasks"),
+        Line::from("h/l - Move task"),
+        Line::from("n - New task"),
+        Line::from("u - Edit task"),
+        Line::from("d - Delete task"),
+        Line::from("a - Assign agent"),
+        Line::from("c - Add comment"),
+        Line::from("L - View logs"),
+        Line::from("A - List agents"),
+        Line::from("O - Show OKRs"),
+    ];
+    let block = Block::default().title("Commands").borders(Borders::ALL);
+    let paragraph = Paragraph::new(lines).block(block).wrap(Wrap { trim: true });
+    let area = centered_rect(60, 50, f.area());
     f.render_widget(Clear, area);
     f.render_widget(paragraph, area);
 }

--- a/tests/cli_commands.rs
+++ b/tests/cli_commands.rs
@@ -18,20 +18,23 @@ fn with_temp_dir<F: FnOnce() -> T, T>(test: F) -> T {
 fn add_list_done_workflow() {
     with_temp_dir(|| {
         // Initialize board
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .arg("init")
             .assert()
             .success();
 
         // Add a task
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .args(["add", "--title", "Test task"])
             .assert()
             .success()
             .stdout(predicate::str::contains("Task added successfully"));
 
         // Verify list output contains the task
-        let out = Command::cargo_bin("taskter").unwrap()
+        let out = Command::cargo_bin("taskter")
+            .unwrap()
             .arg("list")
             .assert()
             .success()
@@ -42,14 +45,16 @@ fn add_list_done_workflow() {
         assert!(output.contains("Test task"));
 
         // Mark the task as done
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .args(["done", "1"])
             .assert()
             .success()
             .stdout(predicate::str::contains("marked as done"));
 
         // Inspect board file
-        let board: Value = serde_json::from_str(&fs::read_to_string(".taskter/board.json").unwrap()).unwrap();
+        let board: Value =
+            serde_json::from_str(&fs::read_to_string(".taskter/board.json").unwrap()).unwrap();
         assert_eq!(board["tasks"][0]["status"], "Done");
     });
 }
@@ -58,33 +63,50 @@ fn add_list_done_workflow() {
 fn add_agent_and_execute_task() {
     with_temp_dir(|| {
         // prepare board
-        Command::cargo_bin("taskter").unwrap().arg("init").assert().success();
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .arg("init")
+            .assert()
+            .success();
 
         // add a task
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .args(["add", "--title", "Send email"])
             .assert()
             .success();
 
         // add agent with builtin tool
-        Command::cargo_bin("taskter").unwrap()
-            .args(["add-agent", "--prompt", "email agent", "--tools", "email", "--model", "gpt-4o"])
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .args([
+                "add-agent",
+                "--prompt",
+                "email agent",
+                "--tools",
+                "email",
+                "--model",
+                "gpt-4o",
+            ])
             .assert()
             .success();
 
         // assign agent to task
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .args(["assign", "--task-id", "1", "--agent-id", "1"])
             .assert()
             .success();
 
         // execute the task
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .args(["execute", "--task-id", "1"])
             .assert()
             .success();
 
-        let board: Value = serde_json::from_str(&fs::read_to_string(".taskter/board.json").unwrap()).unwrap();
+        let board: Value =
+            serde_json::from_str(&fs::read_to_string(".taskter/board.json").unwrap()).unwrap();
         assert_eq!(board["tasks"][0]["status"], "Done");
     });
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -150,3 +150,10 @@ async fn agent_execution_fails_without_tool() {
     // Then
     assert!(matches!(result, ExecutionResult::Failure { .. }));
 }
+
+#[test]
+fn run_python_tool_executes_code() {
+    let result = taskter::tools::execute_tool("run_python", &json!({ "code": "print(40 + 2)" }))
+        .expect("execution failed");
+    assert_eq!(result.trim(), "42");
+}

--- a/tools/run_bash.json
+++ b/tools/run_bash.json
@@ -1,0 +1,11 @@
+{
+  "name": "run_bash",
+  "description": "Execute a bash command and return its output",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "command": { "type": "string", "description": "Shell command to execute" }
+    },
+    "required": ["command"]
+  }
+}

--- a/tools/run_python.json
+++ b/tools/run_python.json
@@ -1,0 +1,11 @@
+{
+  "name": "run_python",
+  "description": "Execute a Python script and return its output",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "code": { "type": "string", "description": "Python code to execute" }
+    },
+    "required": ["code"]
+  }
+}

--- a/tools/web_search.json
+++ b/tools/web_search.json
@@ -1,0 +1,11 @@
+{
+  "name": "web_search",
+  "description": "Perform a web search using DuckDuckGo",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "query": {"type": "string", "description": "Search query"}
+    },
+    "required": ["query"]
+  }
+}


### PR DESCRIPTION
## Summary
- add a web_search built‑in tool that calls DuckDuckGo
- expose the tool through the `tools` module
- list the new tool in the README
- include urlencoding dependency
- apply `cargo fmt` to updated files

## Testing
- `./scripts/precommit.sh`

------
https://chatgpt.com/codex/tasks/task_e_687994a4fd848320ba0e1d2d8a9b75e6