### PR TITLE
Implement 'show tools' command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_name: taskter-linux
+            binary_path: target/release/taskter
+          - os: windows-latest
+            artifact_name: taskter-windows.exe
+            binary_path: target/release/taskter.exe
+          - os: macos-latest
+            artifact_name: taskter-macos
+            binary_path: target/release/taskter
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Build
+        run: cargo build --release
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.binary_path }}
+          if-no-files-found: error
+
+  release:
+    needs: build
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: artifacts/**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +232,21 @@ name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "chumsky"
@@ -760,6 +790,30 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1843,6 +1897,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "chrono",
  "clap",
  "crossterm",
  "lettre",
@@ -2251,6 +2306,41 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.37.0", features = ["full"] }
 lettre = "0.11.17"
+chrono = { version = "0.4", features = ["serde"] }
 [features]
 tui = []
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ taskter add-agent --prompt "You are a helpful assistant that can run bash comman
 You can list all available agents using:
 
 ```bash
-taskter list-agents
+taskter show agents
 ```
 
 To see the available built-in tools, run:
@@ -259,7 +259,7 @@ Taskter now supports LLM-based agents that can be assigned to tasks. These agent
   ```
 - **List available agents:**
   ```bash
-  taskter list-agents
+  taskter show agents
   ```
 - **Delete an agent:**
   ```bash

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ You can list all available agents using:
 taskter list-agents
 ```
 
+To see the available built-in tools, run:
+
+```bash
+taskter show tools
+```
+
 ### 3. Create a task
 
 Now, let's create a task for your agent to complete:
@@ -236,6 +242,11 @@ Taskter now supports LLM-based agents that can be assigned to tasks. These agent
   the repository. For example `email` resolves to `tools/send_email.json`.
   Other built-ins include `create_task`, `assign_agent`, `add_log`, `add_okr`,
   `list_tasks`, `list_agents`, `get_description`, `run_bash`, and `run_python`.
+  You can view this list at any time with:
+
+  ```bash
+  taskter show tools
+  ```
 
 - **Assign an agent to a task:**
   ```bash

--- a/docs/src/agent_system.md
+++ b/docs/src/agent_system.md
@@ -24,6 +24,12 @@ Available built-in tools:
 - `run_python`
 - `send_email`
 
+You can also display this list via the command line:
+
+```bash
+taskter show tools
+```
+
 ## Assigning an Agent to a Task
 
 Once you have created an agent, you can assign it to a task using the `assign` subcommand:

--- a/docs/src/cli_usage.md
+++ b/docs/src/cli_usage.md
@@ -30,6 +30,12 @@ You can list all available agents using:
 taskter list-agents
 ```
 
+You can list the built-in tools with:
+
+```bash
+taskter show tools
+```
+
 ### 3. Create a task
 
 Now, let's create a task for your agent to complete:

--- a/docs/src/cli_usage.md
+++ b/docs/src/cli_usage.md
@@ -27,7 +27,7 @@ taskter add-agent --prompt "You are a helpful assistant that can run bash comman
 You can list all available agents using:
 
 ```bash
-taskter list-agents
+taskter show agents
 ```
 
 You can list the built-in tools with:

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,6 +1,7 @@
 use crate::store::Task;
 use crate::tools;
 use anyhow::Result;
+use chrono::Local;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -20,7 +21,8 @@ fn append_log(message: &str) -> Result<()> {
         .create(true)
         .append(true)
         .open(".taskter/logs.log")?;
-    writeln!(file, "{}", message)?;
+    let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S");
+    writeln!(file, "[{timestamp}] {message}")?;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,8 @@ enum ShowCommands {
     Okrs,
     /// Shows the operation logs
     Logs,
+    /// Lists available built-in tools
+    Tools,
 }
 
 #[tokio::main]
@@ -197,6 +199,11 @@ async fn main() -> anyhow::Result<()> {
             ShowCommands::Logs => {
                 let logs = fs::read_to_string(".taskter/logs.log")?;
                 println!("{logs}");
+            }
+            ShowCommands::Tools => {
+                for name in tools::builtin_names() {
+                    println!("{name}");
+                }
             }
         },
         Commands::AddOkr {

--- a/src/tools/add_log.rs
+++ b/src/tools/add_log.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, Result};
+use chrono::Local;
 use serde_json::Value;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -19,6 +20,7 @@ pub fn execute(args: &Value) -> Result<String> {
         .create(true)
         .append(true)
         .open(".taskter/logs.log")?;
-    writeln!(file, "{message}")?;
+    let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S");
+    writeln!(file, "[{timestamp}] {message}")?;
     Ok("Log entry added".to_string())
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -14,6 +14,20 @@ pub mod list_tasks;
 pub mod run_bash;
 pub mod run_python;
 
+/// List of built-in tool identifiers.
+const BUILTIN_TOOLS: &[&str] = &[
+    "send_email",
+    "create_task",
+    "assign_agent",
+    "add_log",
+    "add_okr",
+    "list_tasks",
+    "list_agents",
+    "run_bash",
+    "run_python",
+    "get_description",
+];
+
 pub fn builtin_declaration(name: &str) -> Option<FunctionDeclaration> {
     match name {
         "send_email" | "email" => Some(email::declaration()),
@@ -28,6 +42,11 @@ pub fn builtin_declaration(name: &str) -> Option<FunctionDeclaration> {
         "get_description" => Some(get_description::declaration()),
         _ => None,
     }
+}
+
+/// Returns the identifiers of all built-in tools.
+pub fn builtin_names() -> Vec<&'static str> {
+    BUILTIN_TOOLS.to_vec()
 }
 
 pub fn execute_tool(name: &str, args: &Value) -> Result<String> {

--- a/tests/cli_commands.rs
+++ b/tests/cli_commands.rs
@@ -18,20 +18,23 @@ fn with_temp_dir<F: FnOnce() -> T, T>(test: F) -> T {
 fn add_list_done_workflow() {
     with_temp_dir(|| {
         // Initialize board
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .arg("init")
             .assert()
             .success();
 
         // Add a task
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .args(["add", "--title", "Test task"])
             .assert()
             .success()
             .stdout(predicate::str::contains("Task added successfully"));
 
         // Verify list output contains the task
-        let out = Command::cargo_bin("taskter").unwrap()
+        let out = Command::cargo_bin("taskter")
+            .unwrap()
             .arg("list")
             .assert()
             .success()
@@ -42,14 +45,16 @@ fn add_list_done_workflow() {
         assert!(output.contains("Test task"));
 
         // Mark the task as done
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .args(["done", "1"])
             .assert()
             .success()
             .stdout(predicate::str::contains("marked as done"));
 
         // Inspect board file
-        let board: Value = serde_json::from_str(&fs::read_to_string(".taskter/board.json").unwrap()).unwrap();
+        let board: Value =
+            serde_json::from_str(&fs::read_to_string(".taskter/board.json").unwrap()).unwrap();
         assert_eq!(board["tasks"][0]["status"], "Done");
     });
 }
@@ -58,33 +63,73 @@ fn add_list_done_workflow() {
 fn add_agent_and_execute_task() {
     with_temp_dir(|| {
         // prepare board
-        Command::cargo_bin("taskter").unwrap().arg("init").assert().success();
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .arg("init")
+            .assert()
+            .success();
 
         // add a task
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .args(["add", "--title", "Send email"])
             .assert()
             .success();
 
         // add agent with builtin tool
-        Command::cargo_bin("taskter").unwrap()
-            .args(["add-agent", "--prompt", "email agent", "--tools", "email", "--model", "gpt-4o"])
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .args([
+                "add-agent",
+                "--prompt",
+                "email agent",
+                "--tools",
+                "email",
+                "--model",
+                "gpt-4o",
+            ])
             .assert()
             .success();
 
         // assign agent to task
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .args(["assign", "--task-id", "1", "--agent-id", "1"])
             .assert()
             .success();
 
         // execute the task
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .args(["execute", "--task-id", "1"])
             .assert()
             .success();
 
-        let board: Value = serde_json::from_str(&fs::read_to_string(".taskter/board.json").unwrap()).unwrap();
+        let board: Value =
+            serde_json::from_str(&fs::read_to_string(".taskter/board.json").unwrap()).unwrap();
         assert_eq!(board["tasks"][0]["status"], "Done");
+    });
+}
+
+#[test]
+fn show_lists_builtin_tools() {
+    with_temp_dir(|| {
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .arg("init")
+            .assert()
+            .success();
+
+        let out = Command::cargo_bin("taskter")
+            .unwrap()
+            .args(["show", "tools"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let output = String::from_utf8(out).unwrap();
+        assert!(output.contains("send_email"));
+        assert!(output.contains("create_task"));
     });
 }

--- a/tests/tool_functions.rs
+++ b/tests/tool_functions.rs
@@ -1,0 +1,222 @@
+use serde_json::json;
+use std::fs;
+
+use taskter::agent::{self, Agent};
+use taskter::store::{self, Board, Task, TaskStatus};
+use taskter::tools::{
+    add_log, add_okr, assign_agent, create_task, get_description, list_agents, list_tasks,
+};
+
+fn with_temp_dir<F: FnOnce() -> T, T>(test: F) -> T {
+    let tmp = tempfile::tempdir().expect("failed to create temp dir");
+    let original_dir = std::env::current_dir().expect("cannot read current dir");
+    std::env::set_current_dir(tmp.path()).expect("cannot set current dir");
+
+    fs::create_dir(".taskter").unwrap();
+
+    let result = test();
+
+    std::env::set_current_dir(original_dir).expect("cannot restore current dir");
+    result
+}
+
+#[test]
+fn create_task_adds_task() {
+    with_temp_dir(|| {
+        let msg = create_task::execute(&json!({"title": "Test", "description": "desc"})).unwrap();
+        assert_eq!(msg, "Created task 1");
+
+        let board = store::load_board().unwrap();
+        assert_eq!(board.tasks.len(), 1);
+        assert_eq!(board.tasks[0].title, "Test");
+        assert_eq!(board.tasks[0].description.as_deref(), Some("desc"));
+    });
+}
+
+#[test]
+fn create_task_requires_title() {
+    with_temp_dir(|| {
+        let err = create_task::execute(&json!({"description": "d"})).unwrap_err();
+        assert!(err.to_string().contains("title missing"));
+    });
+}
+
+#[test]
+fn assign_agent_assigns_task() {
+    with_temp_dir(|| {
+        let task = Task {
+            id: 1,
+            title: "t".into(),
+            description: None,
+            status: TaskStatus::ToDo,
+            agent_id: None,
+            comment: None,
+        };
+        store::save_board(&Board { tasks: vec![task] }).unwrap();
+        let agent = Agent {
+            id: 1,
+            system_prompt: "p".into(),
+            tools: vec![],
+            model: "m".into(),
+        };
+        agent::save_agents(&[agent]).unwrap();
+
+        let msg = assign_agent::execute(&json!({"task_id":1,"agent_id":1})).unwrap();
+        assert_eq!(msg, "Agent 1 assigned to task 1");
+
+        let board = store::load_board().unwrap();
+        assert_eq!(board.tasks[0].agent_id, Some(1));
+    });
+}
+
+#[test]
+fn assign_agent_reports_missing_agent() {
+    with_temp_dir(|| {
+        let task = Task {
+            id: 1,
+            title: "t".into(),
+            description: None,
+            status: TaskStatus::ToDo,
+            agent_id: None,
+            comment: None,
+        };
+        store::save_board(&Board { tasks: vec![task] }).unwrap();
+        let msg = assign_agent::execute(&json!({"task_id":1,"agent_id":1})).unwrap();
+        assert_eq!(msg, "Agent 1 not found");
+    });
+}
+
+#[test]
+fn assign_agent_reports_missing_task() {
+    with_temp_dir(|| {
+        let agent = Agent {
+            id: 1,
+            system_prompt: "p".into(),
+            tools: vec![],
+            model: "m".into(),
+        };
+        agent::save_agents(&[agent]).unwrap();
+        let msg = assign_agent::execute(&json!({"task_id":1,"agent_id":1})).unwrap();
+        assert_eq!(msg, "Task 1 not found");
+    });
+}
+
+#[test]
+fn assign_agent_requires_fields() {
+    with_temp_dir(|| {
+        let err = assign_agent::execute(&json!({"task_id":1})).unwrap_err();
+        assert!(err.to_string().contains("agent_id missing"));
+        let err2 = assign_agent::execute(&json!({"agent_id":1})).unwrap_err();
+        assert!(err2.to_string().contains("task_id missing"));
+    });
+}
+
+#[test]
+fn add_okr_adds_entry() {
+    with_temp_dir(|| {
+        let msg =
+            add_okr::execute(&json!({"objective": "Improve", "key_results": ["speed"]})).unwrap();
+        assert_eq!(msg, "Added OKR 'Improve'");
+        let okrs = store::load_okrs().unwrap();
+        assert_eq!(okrs.len(), 1);
+        assert_eq!(okrs[0].objective, "Improve");
+        assert_eq!(okrs[0].key_results[0].name, "speed");
+    });
+}
+
+#[test]
+fn add_okr_requires_fields() {
+    with_temp_dir(|| {
+        let err = add_okr::execute(&json!({"objective":"o"})).unwrap_err();
+        assert!(err.to_string().contains("key_results missing"));
+        let err2 = add_okr::execute(&json!({"key_results":[]})).unwrap_err();
+        assert!(err2.to_string().contains("objective missing"));
+    });
+}
+
+#[test]
+fn add_log_appends_message() {
+    with_temp_dir(|| {
+        add_log::execute(&json!({"message":"hello"})).unwrap();
+        let content = fs::read_to_string(".taskter/logs.log").unwrap();
+        assert!(content.contains("hello"));
+    });
+}
+
+#[test]
+fn add_log_requires_message() {
+    with_temp_dir(|| {
+        let err = add_log::execute(&json!({})).unwrap_err();
+        assert!(err.to_string().contains("message missing"));
+    });
+}
+
+#[test]
+fn list_agents_outputs_json() {
+    with_temp_dir(|| {
+        let agent = Agent {
+            id: 1,
+            system_prompt: "p".into(),
+            tools: vec![],
+            model: "m".into(),
+        };
+        agent::save_agents(&[agent.clone()]).unwrap();
+        let out = list_agents::execute(&json!({})).unwrap();
+        let parsed: Vec<Agent> = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed[0].id, agent.id);
+    });
+}
+
+#[test]
+fn list_agents_empty_when_none() {
+    with_temp_dir(|| {
+        let out = list_agents::execute(&json!({})).unwrap();
+        assert_eq!(out.trim(), "[]");
+    });
+}
+
+#[test]
+fn list_tasks_outputs_json() {
+    with_temp_dir(|| {
+        let task = Task {
+            id: 1,
+            title: "t".into(),
+            description: None,
+            status: TaskStatus::ToDo,
+            agent_id: None,
+            comment: None,
+        };
+        store::save_board(&Board {
+            tasks: vec![task.clone()],
+        })
+        .unwrap();
+        let out = list_tasks::execute(&json!({})).unwrap();
+        let parsed: Vec<Task> = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed[0].id, task.id);
+    });
+}
+
+#[test]
+fn list_tasks_empty_when_none() {
+    with_temp_dir(|| {
+        let out = list_tasks::execute(&json!({})).unwrap();
+        assert_eq!(out.trim(), "[]");
+    });
+}
+
+#[test]
+fn get_description_reads_file() {
+    with_temp_dir(|| {
+        fs::write(".taskter/description.md", "desc").unwrap();
+        let out = get_description::execute(&json!({})).unwrap();
+        assert_eq!(out, "desc");
+    });
+}
+
+#[test]
+fn get_description_fails_missing_file() {
+    with_temp_dir(|| {
+        let err = get_description::execute(&json!({})).unwrap_err();
+        assert!(err.to_string().contains("No such file"));
+    });
+}


### PR DESCRIPTION
## Summary
- add builtin_names list for available tools
- implement `taskter show tools` subcommand
- document how to display builtin tools in README and docs
- test CLI support for listing tools

## Testing
- `./scripts/precommit.sh`

------
https://chatgpt.com/codex/tasks/task_e_687cf095685483209fb1b54f692fc23c