### PR TITLE
Integrate agent listing into show command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ taskter add-agent --prompt "You are a helpful assistant that can run bash comman
 You can list all available agents using:
 
 ```bash
-taskter list-agents
+taskter show agents
 ```
 
 ### 3. Create a task
@@ -248,7 +248,7 @@ Taskter now supports LLM-based agents that can be assigned to tasks. These agent
   ```
 - **List available agents:**
   ```bash
-  taskter list-agents
+  taskter show agents
   ```
 - **Delete an agent:**
   ```bash

--- a/docs/src/cli_usage.md
+++ b/docs/src/cli_usage.md
@@ -27,7 +27,7 @@ taskter add-agent --prompt "You are a helpful assistant that can run bash comman
 You can list all available agents using:
 
 ```bash
-taskter list-agents
+taskter show agents
 ```
 
 ### 3. Create a task

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,9 +98,6 @@ enum Commands {
         #[arg(short, long)]
         agent_id: usize,
     },
-    /// Lists all agents
-    #[command(name = "list-agents")]
-    ListAgents,
     /// Deletes an agent by id
     #[command(name = "delete-agent")]
     DeleteAgent {
@@ -118,6 +115,8 @@ enum ShowCommands {
     Okrs,
     /// Shows the operation logs
     Logs,
+    /// Lists all agents
+    Agents,
 }
 
 #[tokio::main]
@@ -197,6 +196,12 @@ async fn main() -> anyhow::Result<()> {
             ShowCommands::Logs => {
                 let logs = fs::read_to_string(".taskter/logs.log")?;
                 println!("{logs}");
+            }
+            ShowCommands::Agents => {
+                let agents = agent::list_agents()?;
+                for a in agents {
+                    println!("{}: {}", a.id, a.system_prompt);
+                }
             }
         },
         Commands::AddOkr {
@@ -308,12 +313,6 @@ async fn main() -> anyhow::Result<()> {
                 println!("Agent {agent_id} assigned to task {task_id}.");
             } else {
                 println!("Task with id {task_id} not found.");
-            }
-        }
-        Commands::ListAgents => {
-            let agents = agent::list_agents()?;
-            for a in agents {
-                println!("{}: {}", a.id, a.system_prompt);
             }
         }
         Commands::DeleteAgent { agent_id } => {


### PR DESCRIPTION
## Summary
- remove obsolete `list-agents` command
- add new `Agents` subcommand under `taskter show`
- update docs to use `taskter show agents`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687cf00de8008320866420a22a4f9b18