### PR TITLE
Refactor CLI definitions into library

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,112 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Initializes a new Taskter board
+    Init,
+    /// Adds a new task
+    Add {
+        /// The title of the task
+        #[arg(short, long)]
+        title: String,
+        /// The description of the task
+        #[arg(short, long)]
+        description: Option<String>,
+    },
+    /// Lists all tasks
+    List,
+    /// Marks a task as done
+    Done {
+        /// The id of the task to mark as done
+        id: usize,
+    },
+    /// Adds a comment to a task
+    Comment {
+        /// The id of the task to comment on
+        #[arg(short, long)]
+        task_id: usize,
+        /// The comment text
+        #[arg(short, long)]
+        comment: String,
+    },
+    /// Show project information
+    Show {
+        #[command(subcommand)]
+        what: ShowCommands,
+    },
+    /// Adds a new OKR
+    AddOkr {
+        /// The objective
+        #[arg(short, long)]
+        objective: String,
+        /// The key results
+        #[arg(short, long, num_args = 1..)]
+        key_results: Vec<String>,
+    },
+    /// Adds a log entry
+    Log {
+        /// The log message
+        message: String,
+    },
+    /// Opens the interactive board
+    Board,
+    /// Sets the project description
+    Description {
+        /// The project description
+        description: String,
+    },
+    /// Adds a new agent
+    #[command(name = "add-agent")]
+    AddAgent {
+        /// The system prompt for the agent
+        #[arg(short, long)]
+        prompt: String,
+        /// The tools the agent can use
+        #[arg(short, long, num_args = 1..)]
+        tools: Vec<String>,
+        /// The model to use for the agent
+        #[arg(short, long)]
+        model: String,
+    },
+    /// Executes a task with an agent
+    Execute {
+        /// The id of the task to execute
+        #[arg(short, long)]
+        task_id: usize,
+    },
+    /// Assigns an agent to a task
+    Assign {
+        /// The id of the task to assign
+        #[arg(short, long)]
+        task_id: usize,
+        /// The id of the agent to assign
+        #[arg(short, long)]
+        agent_id: usize,
+    },
+    /// Deletes an agent by id
+    #[command(name = "delete-agent")]
+    DeleteAgent {
+        /// The id of the agent to delete
+        #[arg(short, long)]
+        agent_id: usize,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum ShowCommands {
+    /// Shows the project description
+    Description,
+    /// Shows the project OKRs
+    Okrs,
+    /// Shows the operation logs
+    Logs,
+    /// Lists all agents
+    Agents,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@
 pub mod agent;
 pub mod store;
 pub mod tools;
+pub mod cli;
+
+pub use cli::{Cli, Commands, ShowCommands};
 
 // The TUI heavily depends on a terminal backend which is not easily testable in
 // automated environments. We expose it behind the `tui` feature so that normal

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,124 +1,15 @@
 use chrono::Local;
-use clap::{Parser, Subcommand};
+use clap::Parser;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
 
+use taskter::cli::*;
 mod agent;
 mod store;
 mod tools;
 mod tui;
 
-#[derive(Parser)]
-#[command(author, version, about, long_about = None)]
-struct Cli {
-    #[command(subcommand)]
-    command: Commands,
-}
-
-#[derive(Subcommand)]
-enum Commands {
-    /// Initializes a new Taskter board
-    Init,
-    /// Adds a new task
-    Add {
-        /// The title of the task
-        #[arg(short, long)]
-        title: String,
-        /// The description of the task
-        #[arg(short, long)]
-        description: Option<String>,
-    },
-    /// Lists all tasks
-    List,
-    /// Marks a task as done
-    Done {
-        /// The id of the task to mark as done
-        id: usize,
-    },
-    /// Adds a comment to a task
-    Comment {
-        /// The id of the task to comment on
-        #[arg(short, long)]
-        task_id: usize,
-        /// The comment text
-        #[arg(short, long)]
-        comment: String,
-    },
-    /// Show project information
-    Show {
-        #[command(subcommand)]
-        what: ShowCommands,
-    },
-    /// Adds a new OKR
-    AddOkr {
-        /// The objective
-        #[arg(short, long)]
-        objective: String,
-        /// The key results
-        #[arg(short, long, num_args = 1..)]
-        key_results: Vec<String>,
-    },
-    /// Adds a log entry
-    Log {
-        /// The log message
-        message: String,
-    },
-    /// Opens the interactive board
-    Board,
-    /// Sets the project description
-    Description {
-        /// The project description
-        description: String,
-    },
-    /// Adds a new agent
-    #[command(name = "add-agent")]
-    AddAgent {
-        /// The system prompt for the agent
-        #[arg(short, long)]
-        prompt: String,
-        /// The tools the agent can use
-        #[arg(short, long, num_args = 1..)]
-        tools: Vec<String>,
-        /// The model to use for the agent
-        #[arg(short, long)]
-        model: String,
-    },
-    /// Executes a task with an agent
-    Execute {
-        /// The id of the task to execute
-        #[arg(short, long)]
-        task_id: usize,
-    },
-    /// Assigns an agent to a task
-    Assign {
-        /// The id of the task to assign
-        #[arg(short, long)]
-        task_id: usize,
-        /// The id of the agent to assign
-        #[arg(short, long)]
-        agent_id: usize,
-    },
-    /// Deletes an agent by id
-    #[command(name = "delete-agent")]
-    DeleteAgent {
-        /// The id of the agent to delete
-        #[arg(short, long)]
-        agent_id: usize,
-    },
-}
-
-#[derive(Subcommand)]
-enum ShowCommands {
-    /// Shows the project description
-    Description,
-    /// Shows the project OKRs
-    Okrs,
-    /// Shows the operation logs
-    Logs,
-    /// Lists all agents
-    Agents,
-}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary
- move `Cli` struct and `Commands` enums into `src/cli.rs`
- re-export them from `lib.rs`
- update `main.rs` to use the new `taskter::cli` API

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687d00b29a3c8320a89bd79ff5ce49b4