### PR TITLE
Add text_file tool and list-agents command

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,8 @@ Taskter now supports LLM-based agents that can be assigned to tasks. These agent
   the name of a built-in tool. Built-ins live under the `tools/` directory of
   the repository. For example `email` resolves to `tools/send_email.json`.
   Other built-ins include `create_task`, `assign_agent`, `add_log`, `add_okr`,
-  `list_tasks`, `list_agents`, `get_description`, `run_bash`, and `run_python`.
+  `list_tasks`, `list_agents`, `get_description`, `run_bash`, `run_python`, and
+  `text_file`.
 
 - **Assign an agent to a task:**
   ```bash

--- a/docs/src/agent_system.md
+++ b/docs/src/agent_system.md
@@ -23,6 +23,7 @@ Available built-in tools:
 - `run_bash`
 - `run_python`
 - `send_email`
+- `text_file`
 
 ## Assigning an Agent to a Task
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -97,6 +97,9 @@ pub enum Commands {
         #[arg(short, long)]
         agent_id: usize,
     },
+    /// Lists all agents
+    #[command(name = "list-agents")]
+    ListAgents,
 }
 
 #[derive(Subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,6 +212,12 @@ async fn main() -> anyhow::Result<()> {
             agent::delete_agent(*agent_id)?;
             println!("Agent {agent_id} deleted.");
         }
+        Commands::ListAgents => {
+            let agents = agent::list_agents()?;
+            for a in agents {
+                println!("{}: {}", a.id, a.system_prompt);
+            }
+        }
     }
 
     Ok(())

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -13,6 +13,7 @@ pub mod list_agents;
 pub mod list_tasks;
 pub mod run_bash;
 pub mod run_python;
+pub mod text_file;
 
 pub fn builtin_declaration(name: &str) -> Option<FunctionDeclaration> {
     match name {
@@ -25,6 +26,7 @@ pub fn builtin_declaration(name: &str) -> Option<FunctionDeclaration> {
         "list_agents" => Some(list_agents::declaration()),
         "run_bash" => Some(run_bash::declaration()),
         "run_python" => Some(run_python::declaration()),
+        "text_file" => Some(text_file::declaration()),
         "get_description" => Some(get_description::declaration()),
         _ => None,
     }
@@ -41,6 +43,7 @@ pub fn execute_tool(name: &str, args: &Value) -> Result<String> {
         "list_agents" => list_agents::execute(args),
         "run_bash" => run_bash::execute(args),
         "run_python" => run_python::execute(args),
+        "text_file" => text_file::execute(args),
         "get_description" => get_description::execute(args),
         _ => Err(anyhow::anyhow!("Unknown tool: {}", name)),
     }

--- a/src/tools/text_file.rs
+++ b/src/tools/text_file.rs
@@ -1,0 +1,29 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+
+use crate::agent::FunctionDeclaration;
+
+const DECL_JSON: &str = include_str!("../../tools/text_file.json");
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid text_file.json")
+}
+
+pub fn execute(args: &Value) -> Result<String> {
+    let path = args["path"].as_str().ok_or_else(|| anyhow!("path missing"))?;
+    if let Some(content) = args.get("content").and_then(|v| v.as_str()) {
+        let append = args.get("append").and_then(|v| v.as_bool()).unwrap_or(false);
+        if append {
+            let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+            file.write_all(content.as_bytes())?;
+        } else {
+            fs::write(path, content)?;
+        }
+        Ok("File written".to_string())
+    } else {
+        let data = fs::read_to_string(path)?;
+        Ok(data)
+    }
+}

--- a/tests/tool_functions.rs
+++ b/tests/tool_functions.rs
@@ -5,6 +5,7 @@ use taskter::agent::{self, Agent};
 use taskter::store::{self, Board, Task, TaskStatus};
 use taskter::tools::{
     add_log, add_okr, assign_agent, create_task, get_description, list_agents, list_tasks,
+    text_file,
 };
 
 fn with_temp_dir<F: FnOnce() -> T, T>(test: F) -> T {
@@ -218,5 +219,23 @@ fn get_description_fails_missing_file() {
     with_temp_dir(|| {
         let err = get_description::execute(&json!({})).unwrap_err();
         assert!(err.to_string().contains("No such file"));
+    });
+}
+
+#[test]
+fn text_file_writes_and_reads() {
+    with_temp_dir(|| {
+        let path = ".taskter/note.txt";
+        text_file::execute(&json!({"path": path, "content": "hello"})).unwrap();
+        let out = text_file::execute(&json!({"path": path})).unwrap();
+        assert_eq!(out, "hello");
+    });
+}
+
+#[test]
+fn text_file_requires_path() {
+    with_temp_dir(|| {
+        let err = text_file::execute(&json!({"content": "hi"})).unwrap_err();
+        assert!(err.to_string().contains("path missing"));
     });
 }

--- a/tools/text_file.json
+++ b/tools/text_file.json
@@ -1,0 +1,13 @@
+{
+  "name": "text_file",
+  "description": "Read from or write to a text file. Creates the file if it doesn't exist.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "path": { "type": "string", "description": "Path to the text file" },
+      "content": { "type": "string", "description": "Content to write. Omit to read" },
+      "append": { "type": "boolean", "description": "Append to file instead of overwriting" }
+    },
+    "required": ["path"]
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `text_file` builtin tool for reading/writing text files
- expose new `list-agents` CLI command
- document new tool in README and docs
- extend tool tests for `text_file`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687d67fdc55883208ef4e701bbd285ff