### PR TITLE
Document public API

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -2,40 +2,62 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
 
+/// Status of a task on the board.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum TaskStatus {
+    /// The task has not been started yet.
     ToDo,
+    /// The task is currently in progress.
     InProgress,
+    /// The task is finished.
     Done,
 }
 
+/// A single task entry stored in `.taskter/board.json`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Task {
+    /// Unique identifier of the task.
     pub id: usize,
+    /// Short task title displayed in the board.
     pub title: String,
+    /// Optional longer description.
     pub description: Option<String>,
+    /// Current status of the task.
     pub status: TaskStatus,
+    /// Identifier of the assigned agent, if any.
     pub agent_id: Option<usize>,
+    /// Comment returned by an agent after execution.
     pub comment: Option<String>,
 }
 
+/// Top level container for all tasks.
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq)]
 pub struct Board {
+    /// All tasks recorded in the board.
     pub tasks: Vec<Task>,
 }
 
+/// A single key result belonging to an OKR.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct KeyResult {
+    /// Descriptive name of the key result.
     pub name: String,
+    /// Progress value between 0 and 1.
     pub progress: f32,
 }
 
+/// Objective and its associated key results.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Okr {
+    /// Objective description.
     pub objective: String,
+    /// Key results tracking the objective.
     pub key_results: Vec<KeyResult>,
 }
 
+/// Load the task board from `.taskter/board.json`.
+///
+/// If the file is missing an empty board is returned.
 pub fn load_board() -> anyhow::Result<Board> {
     let path = Path::new(".taskter/board.json");
     if !path.exists() {
@@ -47,6 +69,7 @@ pub fn load_board() -> anyhow::Result<Board> {
     Ok(board)
 }
 
+/// Save the current board state to `.taskter/board.json`.
 pub fn save_board(board: &Board) -> anyhow::Result<()> {
     let path = Path::new(".taskter/board.json");
     let content = serde_json::to_string_pretty(board)?;
@@ -54,6 +77,9 @@ pub fn save_board(board: &Board) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Load OKRs from `.taskter/okrs.json`.
+///
+/// Returns an empty list if the file does not exist.
 pub fn load_okrs() -> anyhow::Result<Vec<Okr>> {
     let path = Path::new(".taskter/okrs.json");
     if !path.exists() {
@@ -65,6 +91,7 @@ pub fn load_okrs() -> anyhow::Result<Vec<Okr>> {
     Ok(okrs)
 }
 
+/// Persist the provided OKRs to `.taskter/okrs.json`.
 pub fn save_okrs(okrs: &[Okr]) -> anyhow::Result<()> {
     let path = Path::new(".taskter/okrs.json");
     let content = serde_json::to_string_pretty(okrs)?;

--- a/src/tools/add_log.rs
+++ b/src/tools/add_log.rs
@@ -8,10 +8,12 @@ use crate::agent::FunctionDeclaration;
 
 const DECL_JSON: &str = include_str!("../../tools/add_log.json");
 
+/// Return the declaration describing this tool.
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid add_log.json")
 }
 
+/// Append a message to `.taskter/logs.log`.
 pub fn execute(args: &Value) -> Result<String> {
     let message = args["message"]
         .as_str()

--- a/src/tools/add_okr.rs
+++ b/src/tools/add_okr.rs
@@ -6,10 +6,12 @@ use crate::store::{self, KeyResult, Okr};
 
 const DECL_JSON: &str = include_str!("../../tools/add_okr.json");
 
+/// Return the declaration for the OKR creation tool.
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid add_okr.json")
 }
 
+/// Add an OKR to `.taskter/okrs.json`.
 pub fn execute(args: &Value) -> Result<String> {
     let objective = args["objective"]
         .as_str()

--- a/src/tools/assign_agent.rs
+++ b/src/tools/assign_agent.rs
@@ -6,10 +6,12 @@ use crate::store;
 
 const DECL_JSON: &str = include_str!("../../tools/assign_agent.json");
 
+/// Return the declaration for the agent assignment tool.
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid assign_agent.json")
 }
 
+/// Assign an agent to a task in `.taskter/board.json`.
 pub fn execute(args: &Value) -> Result<String> {
     let task_id = args["task_id"]
         .as_u64()

--- a/src/tools/create_task.rs
+++ b/src/tools/create_task.rs
@@ -6,10 +6,12 @@ use crate::store::{self, Task, TaskStatus};
 
 const DECL_JSON: &str = include_str!("../../tools/create_task.json");
 
+/// Return the declaration for the task creation tool.
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid create_task.json")
 }
 
+/// Create a new task in `.taskter/board.json`.
 pub fn execute(args: &Value) -> Result<String> {
     let title = args["title"]
         .as_str()

--- a/src/tools/email.rs
+++ b/src/tools/email.rs
@@ -17,10 +17,12 @@ struct EmailConfig {
 
 const DECL_JSON: &str = include_str!("../../tools/send_email.json");
 
+/// Return the declaration for the email sending tool.
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid send_email.json")
 }
 
+/// Send an email using the configuration stored in `.taskter/email_config.json`.
 pub fn execute(args: &Value) -> Result<String> {
     let to = args["to"].as_str().unwrap_or_default();
     let subject = args["subject"].as_str().unwrap_or_default();

--- a/src/tools/get_description.rs
+++ b/src/tools/get_description.rs
@@ -6,10 +6,12 @@ use crate::agent::FunctionDeclaration;
 
 const DECL_JSON: &str = include_str!("../../tools/get_description.json");
 
+/// Return the declaration for the description retrieval tool.
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid get_description.json")
 }
 
+/// Read and return `.taskter/description.md`.
 pub fn execute(_args: &Value) -> Result<String> {
     let content = fs::read_to_string(".taskter/description.md")?;
     Ok(content)

--- a/src/tools/list_agents.rs
+++ b/src/tools/list_agents.rs
@@ -5,10 +5,12 @@ use crate::agent::{self, FunctionDeclaration};
 
 const DECL_JSON: &str = include_str!("../../tools/list_agents.json");
 
+/// Return the declaration for the agent listing tool.
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid list_agents.json")
 }
 
+/// List all agents defined in `.taskter/agents.json`.
 pub fn execute(_args: &Value) -> Result<String> {
     let agents = agent::list_agents()?;
     Ok(serde_json::to_string_pretty(&agents)?)

--- a/src/tools/list_tasks.rs
+++ b/src/tools/list_tasks.rs
@@ -6,10 +6,12 @@ use crate::store;
 
 const DECL_JSON: &str = include_str!("../../tools/list_tasks.json");
 
+/// Return the declaration for the task listing tool.
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid list_tasks.json")
 }
 
+/// List all tasks stored in `.taskter/board.json`.
 pub fn execute(_args: &Value) -> Result<String> {
     let board = store::load_board()?;
     Ok(serde_json::to_string_pretty(&board.tasks)?)

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -14,6 +14,7 @@ pub mod list_tasks;
 pub mod run_bash;
 pub mod run_python;
 
+/// Return the [`FunctionDeclaration`] for one of the built-in tools.
 pub fn builtin_declaration(name: &str) -> Option<FunctionDeclaration> {
     match name {
         "send_email" | "email" => Some(email::declaration()),
@@ -30,6 +31,9 @@ pub fn builtin_declaration(name: &str) -> Option<FunctionDeclaration> {
     }
 }
 
+/// Execute a built-in tool by name.
+///
+/// Many tools persist data under the `.taskter/` directory.
 pub fn execute_tool(name: &str, args: &Value) -> Result<String> {
     match name {
         "send_email" | "email" => email::execute(args),

--- a/src/tools/run_bash.rs
+++ b/src/tools/run_bash.rs
@@ -6,10 +6,12 @@ use crate::agent::FunctionDeclaration;
 
 const DECL_JSON: &str = include_str!("../../tools/run_bash.json");
 
+/// Return the declaration for executing shell commands.
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid run_bash.json")
 }
 
+/// Run a bash command locally and return its output.
 pub fn execute(args: &Value) -> Result<String> {
     let command = args["command"]
         .as_str()

--- a/src/tools/run_python.rs
+++ b/src/tools/run_python.rs
@@ -6,10 +6,12 @@ use crate::agent::FunctionDeclaration;
 
 const DECL_JSON: &str = include_str!("../../tools/run_python.json");
 
+/// Return the declaration for executing Python code.
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid run_python.json")
 }
 
+/// Execute a Python snippet using the local interpreter.
 pub fn execute(args: &Value) -> Result<String> {
     let code = args["code"]
         .as_str()


### PR DESCRIPTION
## Summary
- document all exported structs and functions
- include side effects for `.taskter/` files
- build API docs locally with `cargo doc`

## Testing
- `cargo doc --no-deps`

------
https://chatgpt.com/codex/tasks/task_e_687d7c93a17c832093b272bf81330a54