### PR TITLE
Add tool listing command

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,10 @@ Taskter now supports LLM-based agents that can be assigned to tasks. These agent
   ```bash
   taskter show agents
   ```
+- **List available tools:**
+  ```bash
+  taskter show tools
+  ```
 - **Delete an agent:**
   ```bash
   taskter delete-agent --agent-id 1

--- a/docs/src/agent_system.md
+++ b/docs/src/agent_system.md
@@ -24,6 +24,12 @@ Available built-in tools:
 - `run_python`
 - `send_email`
 
+You can display this list at any time with:
+
+```bash
+taskter show tools
+```
+
 ## Assigning an Agent to a Task
 
 Once you have created an agent, you can assign it to a task using the `assign` subcommand:

--- a/docs/src/cli_usage.md
+++ b/docs/src/cli_usage.md
@@ -30,6 +30,12 @@ You can list all available agents using:
 taskter show agents
 ```
 
+You can list the built-in tools with:
+
+```bash
+taskter show tools
+```
+
 ### 3. Create a task
 
 Now, let's create a task for your agent to complete:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -109,4 +109,6 @@ pub enum ShowCommands {
     Logs,
     /// Lists all agents
     Agents,
+    /// Lists all built-in agent tools
+    Tools,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,9 @@
 //! reused from integration tests and (potentially) other binaries.
 
 pub mod agent;
+pub mod cli;
 pub mod store;
 pub mod tools;
-pub mod cli;
 
 pub use cli::{Cli, Commands, ShowCommands};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ mod store;
 mod tools;
 mod tui;
 
-
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
@@ -93,6 +92,11 @@ async fn main() -> anyhow::Result<()> {
                 let agents = agent::list_agents()?;
                 for a in agents {
                     println!("{}: {}", a.id, a.system_prompt);
+                }
+            }
+            ShowCommands::Tools => {
+                for t in tools::builtin_names() {
+                    println!("{}", t);
                 }
             }
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,7 @@ async fn main() -> anyhow::Result<()> {
             }
             ShowCommands::Tools => {
                 for t in tools::builtin_names() {
-                    println!("{}", t);
+                    println!("{t}");
                 }
             }
         },

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -14,6 +14,25 @@ pub mod list_tasks;
 pub mod run_bash;
 pub mod run_python;
 
+/// List of built-in tool names available to agents.
+pub const BUILTIN_TOOLS: &[&str] = &[
+    "send_email",
+    "create_task",
+    "assign_agent",
+    "add_log",
+    "add_okr",
+    "list_tasks",
+    "list_agents",
+    "run_bash",
+    "run_python",
+    "get_description",
+];
+
+/// Returns the names of all built-in tools.
+pub fn builtin_names() -> Vec<&'static str> {
+    BUILTIN_TOOLS.to_vec()
+}
+
 pub fn builtin_declaration(name: &str) -> Option<FunctionDeclaration> {
     match name {
         "send_email" | "email" => Some(email::declaration()),

--- a/tests/cli_commands.rs
+++ b/tests/cli_commands.rs
@@ -113,17 +113,31 @@ fn add_agent_and_execute_task() {
 #[test]
 fn list_and_delete_agents() {
     with_temp_dir(|| {
-        Command::cargo_bin("taskter").unwrap().arg("init").assert().success();
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .arg("init")
+            .assert()
+            .success();
 
         // add an agent
-        Command::cargo_bin("taskter").unwrap()
-            .args(["add-agent", "--prompt", "helper", "--tools", "email", "--model", "gpt-4o"])
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .args([
+                "add-agent",
+                "--prompt",
+                "helper",
+                "--tools",
+                "email",
+                "--model",
+                "gpt-4o",
+            ])
             .assert()
             .success();
 
         // list agents
-        let out = Command::cargo_bin("taskter").unwrap()
-            .arg("list-agents")
+        let out = Command::cargo_bin("taskter")
+            .unwrap()
+            .args(["show", "agents"])
             .assert()
             .success()
             .get_output()
@@ -133,13 +147,15 @@ fn list_and_delete_agents() {
         assert!(output.contains("1: helper"));
 
         // delete agent
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .args(["delete-agent", "--agent-id", "1"])
             .assert()
             .success()
             .stdout(predicate::str::contains("Agent 1 deleted."));
 
-        let agents: Vec<Value> = serde_json::from_str(&fs::read_to_string(".taskter/agents.json").unwrap()).unwrap();
+        let agents: Vec<Value> =
+            serde_json::from_str(&fs::read_to_string(".taskter/agents.json").unwrap()).unwrap();
         assert!(agents.is_empty());
     });
 }
@@ -147,21 +163,28 @@ fn list_and_delete_agents() {
 #[test]
 fn add_okr_log_and_description() {
     with_temp_dir(|| {
-        Command::cargo_bin("taskter").unwrap().arg("init").assert().success();
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .arg("init")
+            .assert()
+            .success();
 
         // add okr
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .args(["add-okr", "-o", "Improve UI", "-k", "Faster", "Better"])
             .assert()
             .success()
             .stdout(predicate::str::contains("OKR added successfully"));
 
-        let okrs: Value = serde_json::from_str(&fs::read_to_string(".taskter/okrs.json").unwrap()).unwrap();
+        let okrs: Value =
+            serde_json::from_str(&fs::read_to_string(".taskter/okrs.json").unwrap()).unwrap();
         assert_eq!(okrs.as_array().unwrap().len(), 1);
         assert_eq!(okrs[0]["objective"], "Improve UI");
 
         // add log entry
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .args(["log", "Initial commit"])
             .assert()
             .success()
@@ -171,13 +194,39 @@ fn add_okr_log_and_description() {
         assert!(logs.contains("Initial commit"));
 
         // update description
-        Command::cargo_bin("taskter").unwrap()
+        Command::cargo_bin("taskter")
+            .unwrap()
             .args(["description", "A great project"])
             .assert()
             .success()
-            .stdout(predicate::str::contains("Project description updated successfully"));
+            .stdout(predicate::str::contains(
+                "Project description updated successfully",
+            ));
 
         let desc = fs::read_to_string(".taskter/description.md").unwrap();
         assert_eq!(desc, "A great project");
+    });
+}
+
+#[test]
+fn show_tools_lists_builtins() {
+    with_temp_dir(|| {
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .arg("init")
+            .assert()
+            .success();
+
+        let out = Command::cargo_bin("taskter")
+            .unwrap()
+            .args(["show", "tools"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let output = String::from_utf8(out).unwrap();
+        assert!(output.contains("create_task"));
+        assert!(output.contains("run_bash"));
     });
 }


### PR DESCRIPTION
## Summary
- list built-in agent tools via `taskter show tools`
- document the new command in README and book
- update CLI tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687d1309260c83208e45774e40f5e5c8