### PR TITLE
Consolidate test helpers

### DIFF
--- a/tests/cli_commands.rs
+++ b/tests/cli_commands.rs
@@ -3,16 +3,8 @@ use predicates::prelude::*;
 use serde_json::Value;
 use std::fs;
 
-fn with_temp_dir<F: FnOnce() -> T, T>(test: F) -> T {
-    let tmp = tempfile::tempdir().expect("failed to create temp dir");
-    let original_dir = std::env::current_dir().expect("cannot read current dir");
-    std::env::set_current_dir(tmp.path()).expect("cannot set current dir");
-
-    let result = test();
-
-    std::env::set_current_dir(original_dir).expect("cannot restore current dir");
-    result
-}
+mod common;
+pub use common::with_temp_dir;
 
 #[test]
 fn add_list_done_workflow() {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,12 @@
+pub fn with_temp_dir<F: FnOnce() -> T, T>(test: F) -> T {
+    let tmp = tempfile::tempdir().expect("failed to create temp dir");
+    let original_dir = std::env::current_dir().expect("cannot read current dir");
+    std::env::set_current_dir(tmp.path()).expect("cannot set current dir");
+
+    std::fs::create_dir(".taskter").unwrap();
+
+    let result = test();
+
+    std::env::set_current_dir(original_dir).expect("cannot restore current dir");
+    result
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,23 +1,9 @@
-use std::fs;
-
 use serde_json::json;
 use taskter::agent::{self, Agent, ExecutionResult, FunctionDeclaration};
 use taskter::store::{self, Board, KeyResult, Okr, Task, TaskStatus};
 
-// Helper that creates a temporary workspace and changes the current directory to it.
-fn with_temp_dir<F: FnOnce() -> T, T>(test: F) -> T {
-    let tmp = tempfile::tempdir().expect("failed to create temp dir");
-    let original_dir = std::env::current_dir().expect("cannot read current dir");
-    std::env::set_current_dir(tmp.path()).expect("cannot set current dir");
-
-    // Each Taskter invocation expects the .taskter directory to exist. We'll ensure it's present.
-    fs::create_dir(".taskter").unwrap();
-
-    let result = test();
-
-    std::env::set_current_dir(original_dir).expect("cannot restore current dir");
-    result
-}
+mod common;
+pub use common::with_temp_dir;
 
 #[test]
 fn board_roundtrip_persists_tasks() {

--- a/tests/tool_functions.rs
+++ b/tests/tool_functions.rs
@@ -7,18 +7,8 @@ use taskter::tools::{
     add_log, add_okr, assign_agent, create_task, get_description, list_agents, list_tasks,
 };
 
-fn with_temp_dir<F: FnOnce() -> T, T>(test: F) -> T {
-    let tmp = tempfile::tempdir().expect("failed to create temp dir");
-    let original_dir = std::env::current_dir().expect("cannot read current dir");
-    std::env::set_current_dir(tmp.path()).expect("cannot set current dir");
-
-    fs::create_dir(".taskter").unwrap();
-
-    let result = test();
-
-    std::env::set_current_dir(original_dir).expect("cannot restore current dir");
-    result
-}
+mod common;
+pub use common::with_temp_dir;
 
 #[test]
 fn create_task_adds_task() {


### PR DESCRIPTION
## Summary
- add a `tests/common` module with a shared `with_temp_dir` helper
- import that helper in all test files and remove local copies

## Testing
- `cargo fmt -- --check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687d90abb70083209856444adc19eeab