### PR TITLE
Improve configuration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,35 +292,41 @@ In the interactive board (`taskter board`), tasks assigned to an agent will be m
 
 ### Email configuration
 
-Agent email tools read credentials from `.taskter/email_config.json`.  At the
-moment only SMTP settings are required by the `send_email` tool, but IMAP
-details can also be provided for future extensions.  Create the file with the
-following structure:
+Agent email tools read credentials from `.taskter/email_config.json`. Place this
+file inside the board directory (next to `board.json` and `agents.json`). All
+agents share the same configuration. The currently recognised keys are:
 
 ```json
 {
   "smtp_server": "smtp.example.com",
   "smtp_port": 587,
-  "imap_server": "imap.example.com",
-  "imap_port": 993,
   "username": "user@example.com",
-  "password": "secret"
+  "password": "secret",
+  "imap_server": "imap.example.com",  // optional
+  "imap_port": 993                   // optional
 }
 ```
 
-All agents will use the same configuration file. If the file is missing, the
-`send_email` tool will gracefully fall back to a no-op so tests and offline
-usage keep working.
+Only the SMTP fields are used by the built-in `send_email` tool today. There are
+no default values, so you must supply valid server details. If the file is
+missing the tool returns `Email configuration not found`. When the application
+runs without a `GEMINI_API_KEY` the email tool is skipped entirely, which keeps
+tests working even without credentials.
 
 
 ### Gemini API key
 
-Agent execution uses the Gemini API, so the `GEMINI_API_KEY` environment
-variable must be set. For example:
+Agent execution uses the Gemini API. Provide the `GEMINI_API_KEY` environment
+variable when you want agents to call the real service. If the variable is
+absent or empty, Taskter falls back to an offline mode where only built-in
+tools are executed.
 
 ```bash
 export GEMINI_API_KEY=your_key_here
 ```
+
+See the book's **Configuration** chapter for a detailed explanation of this
+variable and the email configuration file.
 
 ### Example project
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,4 +5,5 @@
 - [CLI Usage](cli_usage.md)
 - [TUI Guide](tui_guide.md)
 - [Agent System](agent_system.md)
+- [Configuration](configuration.md)
 - [Contributing](contributing.md)

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -1,0 +1,35 @@
+# Configuration
+
+This chapter describes runtime configuration files and environment variables used by Taskter.
+
+## Email configuration file
+
+Email-based tools expect credentials in `.taskter/email_config.json` inside your project. Every agent reads the same file.
+
+```json
+{
+  "smtp_server": "smtp.example.com",
+  "smtp_port": 587,
+  "username": "user@example.com",
+  "password": "secret",
+  "imap_server": "imap.example.com",  // optional
+  "imap_port": 993                    // optional
+}
+```
+
+Currently only the SMTP fields are used by the `send_email` tool. The IMAP keys are accepted for future extensions. No default values are provided, so fill in the details that match your mail provider.
+
+If the file is missing the tool outputs `Email configuration not found`. When Taskter runs without a `GEMINI_API_KEY`, email tools are skipped entirely so the file is not required for tests.
+
+## Environment variables
+
+Taskter looks for a single environment variable:
+
+- `GEMINI_API_KEY` — API key for the Gemini model. When set, agents can call the remote API. If absent or empty Taskter stays in offline mode and only uses built-in tools.
+
+Set it directly in your shell or via Docker Compose:
+
+```bash
+export GEMINI_API_KEY=your_key_here
+```
+


### PR DESCRIPTION
## Summary
- document `.taskter/email_config.json` in more detail
- clarify `GEMINI_API_KEY` behaviour
- add new Configuration page to the docs

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687d920649ac8320ba0e626aa59d3b40