### PR TITLE
Refactor TUI into modules

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,0 +1,164 @@
+use crate::agent::Agent;
+use crate::store::{self, Board, Okr, Task, TaskStatus};
+use ratatui::widgets::ListState;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Copy)]
+pub(crate) enum View {
+    Board,
+    TaskDescription,
+    AssignAgent,
+    AddComment,
+    AddTask,
+    UpdateTask,
+    Logs,
+    Agents,
+    Okrs,
+    Commands,
+}
+
+pub(crate) struct App {
+    pub(crate) board: Arc<Mutex<Board>>,
+    pub(crate) agents: Vec<Agent>,
+    pub(crate) selected_column: usize,
+    pub(crate) selected_task: [ListState; 3],
+    pub(crate) current_view: View,
+    pub(crate) agent_list_state: ListState,
+    pub(crate) comment_input: String,
+    pub(crate) new_task_title: String,
+    pub(crate) new_task_description: String,
+    pub(crate) editing_description: bool,
+    pub(crate) logs: String,
+    pub(crate) okrs: Vec<Okr>,
+}
+
+impl App {
+    pub(crate) fn new(board: Board, agents: Vec<Agent>) -> Self {
+        let mut app = App {
+            board: Arc::new(Mutex::new(board)),
+            agents,
+            selected_column: 0,
+            selected_task: [
+                ListState::default(),
+                ListState::default(),
+                ListState::default(),
+            ],
+            current_view: View::Board,
+            agent_list_state: ListState::default(),
+            comment_input: String::new(),
+            new_task_title: String::new(),
+            new_task_description: String::new(),
+            editing_description: false,
+            logs: std::fs::read_to_string(".taskter/logs.log").unwrap_or_default(),
+            okrs: store::load_okrs().unwrap_or_default(),
+        };
+        app.selected_task[0].select(Some(0));
+        app
+    }
+
+    pub(crate) fn next_column(&mut self) {
+        self.selected_column = (self.selected_column + 1) % 3;
+        self.ensure_selected_task();
+    }
+
+    pub(crate) fn prev_column(&mut self) {
+        self.selected_column = (self.selected_column + 2) % 3;
+        self.ensure_selected_task();
+    }
+
+    fn ensure_selected_task(&mut self) {
+        let tasks = self.tasks_in_current_column();
+        if !tasks.is_empty()
+            && self.selected_task[self.selected_column]
+                .selected()
+                .is_none()
+        {
+            self.selected_task[self.selected_column].select(Some(0));
+        }
+    }
+
+    pub(crate) fn next_task(&mut self) {
+        let tasks = self.tasks_in_current_column();
+        if tasks.is_empty() {
+            return;
+        }
+        let i = match self.selected_task[self.selected_column].selected() {
+            Some(i) => (i + 1) % tasks.len(),
+            None => 0,
+        };
+        self.selected_task[self.selected_column].select(Some(i));
+    }
+
+    pub(crate) fn prev_task(&mut self) {
+        let tasks = self.tasks_in_current_column();
+        if tasks.is_empty() {
+            return;
+        }
+        let i = match self.selected_task[self.selected_column].selected() {
+            Some(i) => (i + tasks.len() - 1) % tasks.len(),
+            None => 0,
+        };
+        self.selected_task[self.selected_column].select(Some(i));
+    }
+
+    pub(crate) fn tasks_in_current_column(&self) -> Vec<Task> {
+        let status = match self.selected_column {
+            0 => TaskStatus::ToDo,
+            1 => TaskStatus::InProgress,
+            _ => TaskStatus::Done,
+        };
+        self.board
+            .lock()
+            .unwrap()
+            .tasks
+            .iter()
+            .filter(|t| t.status == status)
+            .cloned()
+            .collect()
+    }
+
+    pub(crate) fn move_task_to_next_column(&mut self) {
+        self.move_task(1);
+    }
+
+    pub(crate) fn move_task_to_prev_column(&mut self) {
+        self.move_task(-1);
+    }
+
+    fn move_task(&mut self, direction: i8) {
+        let task_id_to_move = if let Some(selected_index) = self.selected_task[self.selected_column].selected() {
+            let tasks_in_column = self.tasks_in_current_column();
+            tasks_in_column.get(selected_index).map(|t| t.id)
+        } else {
+            None
+        };
+
+        if let Some(task_id) = task_id_to_move {
+            if let Some(task) = self
+                .board
+                .lock()
+                .unwrap()
+                .tasks
+                .iter_mut()
+                .find(|t| t.id == task_id)
+            {
+                let current_status_index = task.status.clone() as usize;
+                let next_status_index = (current_status_index as i8 + direction + 3) % 3;
+                task.status = match next_status_index {
+                    0 => TaskStatus::ToDo,
+                    1 => TaskStatus::InProgress,
+                    _ => TaskStatus::Done,
+                };
+            }
+        }
+    }
+
+    pub(crate) fn get_selected_task(&self) -> Option<Task> {
+        self.selected_task[self.selected_column]
+            .selected()
+            .and_then(|selected_index| {
+                let tasks_in_column = self.tasks_in_current_column();
+                tasks_in_column.get(selected_index).cloned()
+            })
+    }
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -126,12 +126,13 @@ impl App {
     }
 
     fn move_task(&mut self, direction: i8) {
-        let task_id_to_move = if let Some(selected_index) = self.selected_task[self.selected_column].selected() {
-            let tasks_in_column = self.tasks_in_current_column();
-            tasks_in_column.get(selected_index).map(|t| t.id)
-        } else {
-            None
-        };
+        let task_id_to_move =
+            if let Some(selected_index) = self.selected_task[self.selected_column].selected() {
+                let tasks_in_column = self.tasks_in_current_column();
+                tasks_in_column.get(selected_index).map(|t| t.id)
+            } else {
+                None
+            };
 
         if let Some(task_id) = task_id_to_move {
             if let Some(task) = self

--- a/src/tui/handlers.rs
+++ b/src/tui/handlers.rs
@@ -144,7 +144,8 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                             }
                         }
                         KeyCode::Char('L') => {
-                            app.logs = std::fs::read_to_string(".taskter/logs.log").unwrap_or_default();
+                            app.logs =
+                                std::fs::read_to_string(".taskter/logs.log").unwrap_or_default();
                             app.current_view = View::Logs;
                         }
                         KeyCode::Char('A') => {
@@ -199,7 +200,8 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                                         let board_clone = Arc::clone(&app.board);
                                         tokio::spawn(async move {
                                             let result =
-                                                agent::execute_task(&agent_clone, &task_clone).await;
+                                                agent::execute_task(&agent_clone, &task_clone)
+                                                    .await;
                                             let mut board = board_clone.lock().unwrap();
                                             if let Some(task) = board
                                                 .tasks
@@ -208,11 +210,15 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                                             {
                                                 match result {
                                                     Ok(result) => match result {
-                                                        agent::ExecutionResult::Success { comment } => {
+                                                        agent::ExecutionResult::Success {
+                                                            comment,
+                                                        } => {
                                                             task.status = store::TaskStatus::Done;
                                                             task.comment = Some(comment);
                                                         }
-                                                        agent::ExecutionResult::Failure { comment } => {
+                                                        agent::ExecutionResult::Failure {
+                                                            comment,
+                                                        } => {
                                                             task.status = store::TaskStatus::ToDo;
                                                             task.comment = Some(comment);
                                                             task.agent_id = None;
@@ -220,7 +226,9 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                                                     },
                                                     Err(_) => {
                                                         task.status = store::TaskStatus::ToDo;
-                                                        task.comment = Some("Failed to execute task.".to_string());
+                                                        task.comment = Some(
+                                                            "Failed to execute task.".to_string(),
+                                                        );
                                                         task.agent_id = None;
                                                     }
                                                 }

--- a/src/tui/handlers.rs
+++ b/src/tui/handlers.rs
@@ -1,180 +1,18 @@
-use crate::agent::{self, Agent};
-use crate::store::{self, Board, Okr, Task, TaskStatus};
+use super::app::{App, View};
+use super::render::ui;
+use crate::agent::{self};
+use crate::store::{self, Task, TaskStatus};
 use crossterm::{
     event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use notify::{recommended_watcher, RecursiveMode, Watcher};
-use ratatui::{
-    prelude::*,
-    text::{Line, Span},
-    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
-};
+use ratatui::prelude::*;
 use std::io;
 use std::path::Path;
-use std::sync::{mpsc::channel, Arc, Mutex};
+use std::sync::{mpsc::channel, Arc};
 use std::time::Duration;
-
-enum View {
-    Board,
-    TaskDescription,
-    AssignAgent,
-    AddComment,
-    AddTask,
-    UpdateTask,
-    Logs,
-    Agents,
-    Okrs,
-    Commands,
-}
-
-struct App {
-    board: Arc<Mutex<Board>>,
-    agents: Vec<Agent>,
-    selected_column: usize,
-    selected_task: [ListState; 3],
-    current_view: View,
-    agent_list_state: ListState,
-    comment_input: String,
-    new_task_title: String,
-    new_task_description: String,
-    editing_description: bool,
-    logs: String,
-    okrs: Vec<Okr>,
-}
-
-impl App {
-    fn new(board: Board, agents: Vec<Agent>) -> Self {
-        let mut app = App {
-            board: Arc::new(Mutex::new(board)),
-            agents,
-            selected_column: 0,
-            selected_task: [
-                ListState::default(),
-                ListState::default(),
-                ListState::default(),
-            ],
-            current_view: View::Board,
-            agent_list_state: ListState::default(),
-            comment_input: String::new(),
-            new_task_title: String::new(),
-            new_task_description: String::new(),
-            editing_description: false,
-            logs: std::fs::read_to_string(".taskter/logs.log").unwrap_or_default(),
-            okrs: store::load_okrs().unwrap_or_default(),
-        };
-        app.selected_task[0].select(Some(0));
-        app
-    }
-
-    fn next_column(&mut self) {
-        self.selected_column = (self.selected_column + 1) % 3;
-        self.ensure_selected_task();
-    }
-
-    fn prev_column(&mut self) {
-        self.selected_column = (self.selected_column + 2) % 3;
-        self.ensure_selected_task();
-    }
-
-    fn ensure_selected_task(&mut self) {
-        let tasks = self.tasks_in_current_column();
-        if !tasks.is_empty()
-            && self.selected_task[self.selected_column]
-                .selected()
-                .is_none()
-        {
-            self.selected_task[self.selected_column].select(Some(0));
-        }
-    }
-
-    fn next_task(&mut self) {
-        let tasks = self.tasks_in_current_column();
-        if tasks.is_empty() {
-            return;
-        }
-        let i = match self.selected_task[self.selected_column].selected() {
-            Some(i) => (i + 1) % tasks.len(),
-            None => 0,
-        };
-        self.selected_task[self.selected_column].select(Some(i));
-    }
-
-    fn prev_task(&mut self) {
-        let tasks = self.tasks_in_current_column();
-        if tasks.is_empty() {
-            return;
-        }
-        let i = match self.selected_task[self.selected_column].selected() {
-            Some(i) => (i + tasks.len() - 1) % tasks.len(),
-            None => 0,
-        };
-        self.selected_task[self.selected_column].select(Some(i));
-    }
-
-    fn tasks_in_current_column(&self) -> Vec<Task> {
-        let status = match self.selected_column {
-            0 => TaskStatus::ToDo,
-            1 => TaskStatus::InProgress,
-            _ => TaskStatus::Done,
-        };
-        self.board
-            .lock()
-            .unwrap()
-            .tasks
-            .iter()
-            .filter(|t| t.status == status)
-            .cloned()
-            .collect()
-    }
-
-    fn move_task_to_next_column(&mut self) {
-        self.move_task(1);
-    }
-
-    fn move_task_to_prev_column(&mut self) {
-        self.move_task(-1);
-    }
-
-    fn move_task(&mut self, direction: i8) {
-        let task_id_to_move =
-            if let Some(selected_index) = self.selected_task[self.selected_column].selected() {
-                let tasks_in_column = self.tasks_in_current_column();
-                tasks_in_column.get(selected_index).map(|t| t.id)
-            } else {
-                None
-            };
-
-        if let Some(task_id) = task_id_to_move {
-            if let Some(task) = self
-                .board
-                .lock()
-                .unwrap()
-                .tasks
-                .iter_mut()
-                .find(|t| t.id == task_id)
-            {
-                let current_status_index = task.status.clone() as usize;
-                let next_status_index = (current_status_index as i8 + direction + 3) % 3;
-                task.status = match next_status_index {
-                    0 => TaskStatus::ToDo,
-                    1 => TaskStatus::InProgress,
-                    _ => TaskStatus::Done,
-                };
-            }
-        }
-    }
-
-    fn get_selected_task(&self) -> Option<Task> {
-        self.selected_task[self.selected_column]
-            .selected()
-            .and_then(|selected_index| {
-                let tasks_in_column = self.tasks_in_current_column();
-                tasks_in_column.get(selected_index).cloned()
-            })
-    }
-}
 
 pub fn run_tui() -> anyhow::Result<()> {
     enable_raw_mode()?;
@@ -204,9 +42,7 @@ pub fn run_tui() -> anyhow::Result<()> {
 }
 
 fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<()> {
-    // channel receiving filesystem events
     let (tx, rx) = channel();
-    // set up watcher to monitor board, okrs, logs and agents files
     let mut watcher = recommended_watcher(move |res| {
         let _ = tx.send(res);
     })
@@ -224,7 +60,6 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
     }
 
     loop {
-        // handle filesystem events and reload data if needed
         while let Ok(res) = rx.try_recv() {
             if let Ok(event) = res {
                 for p in event.paths {
@@ -309,8 +144,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                             }
                         }
                         KeyCode::Char('L') => {
-                            app.logs =
-                                std::fs::read_to_string(".taskter/logs.log").unwrap_or_default();
+                            app.logs = std::fs::read_to_string(".taskter/logs.log").unwrap_or_default();
                             app.current_view = View::Logs;
                         }
                         KeyCode::Char('A') => {
@@ -365,8 +199,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                                         let board_clone = Arc::clone(&app.board);
                                         tokio::spawn(async move {
                                             let result =
-                                                agent::execute_task(&agent_clone, &task_clone)
-                                                    .await;
+                                                agent::execute_task(&agent_clone, &task_clone).await;
                                             let mut board = board_clone.lock().unwrap();
                                             if let Some(task) = board
                                                 .tasks
@@ -375,15 +208,11 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                                             {
                                                 match result {
                                                     Ok(result) => match result {
-                                                        agent::ExecutionResult::Success {
-                                                            comment,
-                                                        } => {
+                                                        agent::ExecutionResult::Success { comment } => {
                                                             task.status = store::TaskStatus::Done;
                                                             task.comment = Some(comment);
                                                         }
-                                                        agent::ExecutionResult::Failure {
-                                                            comment,
-                                                        } => {
+                                                        agent::ExecutionResult::Failure { comment } => {
                                                             task.status = store::TaskStatus::ToDo;
                                                             task.comment = Some(comment);
                                                             task.agent_id = None;
@@ -391,9 +220,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                                                     },
                                                     Err(_) => {
                                                         task.status = store::TaskStatus::ToDo;
-                                                        task.comment = Some(
-                                                            "Failed to execute task.".to_string(),
-                                                        );
+                                                        task.comment = Some("Failed to execute task.".to_string());
                                                         task.agent_id = None;
                                                     }
                                                 }
@@ -536,287 +363,4 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
             }
         }
     }
-}
-
-fn ui(f: &mut Frame, app: &mut App) {
-    render_board(f, app);
-    match app.current_view {
-        View::TaskDescription => render_task_description(f, app),
-        View::AssignAgent => render_assign_agent(f, app),
-        View::AddComment => render_add_comment(f, app),
-        View::AddTask => render_add_task(f, app),
-        View::UpdateTask => render_update_task(f, app),
-        View::Logs => render_logs(f, app),
-        View::Agents => render_agents_list(f, app),
-        View::Okrs => render_okrs(f, app),
-        View::Commands => render_commands(f),
-        _ => {}
-    }
-}
-
-fn render_board(f: &mut Frame, app: &mut App) {
-    let chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints(
-            [
-                Constraint::Percentage(33),
-                Constraint::Percentage(33),
-                Constraint::Percentage(34),
-            ]
-            .as_ref(),
-        )
-        .split(f.area());
-
-    for (i, status) in [TaskStatus::ToDo, TaskStatus::InProgress, TaskStatus::Done]
-        .iter()
-        .enumerate()
-    {
-        let tasks: Vec<ListItem> = app
-            .board
-            .lock()
-            .unwrap()
-            .tasks
-            .iter()
-            .filter(|t| t.status == *status)
-            .map(|t| {
-                let title = if t.agent_id.is_some() {
-                    format!("* {}", t.title)
-                } else {
-                    t.title.clone()
-                };
-                ListItem::new(title)
-            })
-            .collect();
-        let mut list = List::new(tasks).block(
-            Block::default()
-                .title(format!("{status:?}"))
-                .borders(Borders::ALL),
-        );
-        if app.selected_column == i {
-            list = list.highlight_style(
-                Style::default()
-                    .add_modifier(Modifier::BOLD)
-                    .bg(Color::Blue),
-            );
-        }
-        f.render_stateful_widget(list, chunks[i], &mut app.selected_task[i]);
-    }
-}
-
-fn render_task_description(f: &mut Frame, app: &mut App) {
-    if let Some(task) = app.get_selected_task() {
-        let mut text = vec![
-            Line::from(Span::styled(
-                task.title.clone(),
-                Style::default().add_modifier(Modifier::BOLD),
-            )),
-            Line::from(task.description.clone().unwrap_or_default()),
-        ];
-
-        if let Some(agent_id) = task.agent_id {
-            text.push(Line::from(format!("Assigned to agent: {agent_id}")));
-        }
-
-        if let Some(comment) = &task.comment {
-            text.push(Line::from(Span::styled(
-                format!("Comment: {comment}"),
-                Style::default().fg(Color::Yellow),
-            )));
-        }
-
-        let block = Block::default()
-            .title("Task Description")
-            .borders(Borders::ALL);
-        let paragraph = Paragraph::new(text).block(block).wrap(Wrap { trim: true });
-        let area = centered_rect(60, 25, f.area());
-        f.render_widget(Clear, area); //this clears the background
-        f.render_widget(paragraph, area);
-    }
-}
-
-fn render_assign_agent(f: &mut Frame, app: &mut App) {
-    if app.agents.is_empty() {
-        let block = Block::default().title("Assign Agent").borders(Borders::ALL);
-        let text = Paragraph::new("No agents available. Create one with `taskter add-agent`")
-            .block(block)
-            .wrap(Wrap { trim: true });
-        let area = centered_rect(60, 25, f.area());
-        f.render_widget(Clear, area);
-        f.render_widget(text, area);
-        return;
-    }
-
-    let agents: Vec<ListItem> = app
-        .agents
-        .iter()
-        .map(|a| ListItem::new(a.system_prompt.as_str()))
-        .collect();
-
-    let agent_list = List::new(agents)
-        .block(Block::default().title("Assign Agent").borders(Borders::ALL))
-        .highlight_style(
-            Style::default()
-                .add_modifier(Modifier::BOLD)
-                .bg(Color::Blue),
-        );
-
-    let area = centered_rect(60, 25, f.area());
-    f.render_widget(Clear, area);
-    f.render_stateful_widget(agent_list, area, &mut app.agent_list_state);
-}
-
-fn render_add_comment(f: &mut Frame, app: &mut App) {
-    let block = Block::default().title("Add Comment").borders(Borders::ALL);
-    let paragraph = Paragraph::new(app.comment_input.as_str())
-        .block(block)
-        .wrap(Wrap { trim: true });
-    let area = centered_rect(60, 25, f.area());
-    f.render_widget(Clear, area);
-    f.render_widget(paragraph, area);
-}
-
-fn render_add_task(f: &mut Frame, app: &mut App) {
-    let block = Block::default().title("New Task").borders(Borders::ALL);
-    let title_style = if !app.editing_description {
-        Style::default().fg(Color::Yellow)
-    } else {
-        Style::default()
-    };
-    let desc_style = if app.editing_description {
-        Style::default().fg(Color::Yellow)
-    } else {
-        Style::default()
-    };
-    let paragraph = Paragraph::new(vec![
-        Line::from(vec![
-            Span::raw("Title: "),
-            Span::styled(app.new_task_title.as_str(), title_style),
-        ]),
-        Line::from(vec![
-            Span::raw("Description: "),
-            Span::styled(app.new_task_description.as_str(), desc_style),
-        ]),
-    ])
-    .block(block)
-    .wrap(Wrap { trim: true });
-    let area = centered_rect(60, 15, f.area());
-    f.render_widget(Clear, area);
-    f.render_widget(paragraph, area);
-}
-
-fn render_update_task(f: &mut Frame, app: &mut App) {
-    let block = Block::default().title("Edit Task").borders(Borders::ALL);
-    let title_style = if !app.editing_description {
-        Style::default().fg(Color::Yellow)
-    } else {
-        Style::default()
-    };
-    let desc_style = if app.editing_description {
-        Style::default().fg(Color::Yellow)
-    } else {
-        Style::default()
-    };
-    let paragraph = Paragraph::new(vec![
-        Line::from(vec![
-            Span::raw("Title: "),
-            Span::styled(app.new_task_title.as_str(), title_style),
-        ]),
-        Line::from(vec![
-            Span::raw("Description: "),
-            Span::styled(app.new_task_description.as_str(), desc_style),
-        ]),
-    ])
-    .block(block)
-    .wrap(Wrap { trim: true });
-    let area = centered_rect(60, 15, f.area());
-    f.render_widget(Clear, area);
-    f.render_widget(paragraph, area);
-}
-
-fn render_logs(f: &mut Frame, app: &mut App) {
-    let block = Block::default().title("Logs").borders(Borders::ALL);
-    let paragraph = Paragraph::new(app.logs.as_str())
-        .block(block)
-        .wrap(Wrap { trim: true });
-    let area = centered_rect(60, 50, f.area());
-    f.render_widget(Clear, area);
-    f.render_widget(paragraph, area);
-}
-
-fn render_agents_list(f: &mut Frame, app: &mut App) {
-    let items: Vec<ListItem> = app
-        .agents
-        .iter()
-        .map(|a| ListItem::new(format!("{}: {}", a.id, a.system_prompt)))
-        .collect();
-    let list = List::new(items).block(Block::default().title("Agents").borders(Borders::ALL));
-    let area = centered_rect(60, 25, f.area());
-    f.render_widget(Clear, area);
-    f.render_widget(list, area);
-}
-
-fn render_okrs(f: &mut Frame, app: &mut App) {
-    let mut lines = Vec::new();
-    for okr in &app.okrs {
-        lines.push(Line::from(Span::styled(
-            &okr.objective,
-            Style::default().add_modifier(Modifier::BOLD),
-        )));
-        for kr in &okr.key_results {
-            lines.push(Line::from(format!(
-                " - {} ({:.0}%)",
-                kr.name,
-                kr.progress * 100.0
-            )));
-        }
-        lines.push(Line::raw(""));
-    }
-    let block = Block::default().title("OKRs").borders(Borders::ALL);
-    let paragraph = Paragraph::new(lines).block(block).wrap(Wrap { trim: true });
-    let area = centered_rect(60, 50, f.area());
-    f.render_widget(Clear, area);
-    f.render_widget(paragraph, area);
-}
-
-fn render_commands(f: &mut Frame) {
-    let lines = vec![
-        Line::from("q - Quit"),
-        Line::from("←/→ or Tab - Switch columns"),
-        Line::from("↑/↓ - Navigate tasks"),
-        Line::from("h/l - Move task"),
-        Line::from("n - New task"),
-        Line::from("u - Edit task"),
-        Line::from("d - Delete task"),
-        Line::from("a - Assign agent"),
-        Line::from("c - Add comment"),
-        Line::from("L - View logs"),
-        Line::from("A - List agents"),
-        Line::from("O - Show OKRs"),
-    ];
-    let block = Block::default().title("Commands").borders(Borders::ALL);
-    let paragraph = Paragraph::new(lines).block(block).wrap(Wrap { trim: true });
-    let area = centered_rect(60, 50, f.area());
-    f.render_widget(Clear, area);
-    f.render_widget(paragraph, area);
-}
-
-/// helper function to create a centered rect using up certain percentage of the available rect `r`
-fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
-    let popup_layout = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Percentage((100 - percent_y) / 2),
-            Constraint::Percentage(percent_y),
-            Constraint::Percentage((100 - percent_y) / 2),
-        ])
-        .split(r);
-
-    Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Percentage((100 - percent_x) / 2),
-            Constraint::Percentage(percent_x),
-            Constraint::Percentage((100 - percent_x) / 2),
-        ])
-        .split(popup_layout[1])[1]
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,0 +1,5 @@
+pub mod app;
+mod handlers;
+mod render;
+
+pub use handlers::run_tui;

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1,10 +1,10 @@
 use super::app::{App, View};
+use crate::store::TaskStatus;
 use ratatui::{
     prelude::*,
     text::{Line, Span},
     widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap},
 };
-use crate::store::TaskStatus;
 
 pub(crate) fn ui(f: &mut Frame, app: &mut App) {
     render_board(f, app);

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1,0 +1,290 @@
+use super::app::{App, View};
+use ratatui::{
+    prelude::*,
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap},
+};
+use crate::store::TaskStatus;
+
+pub(crate) fn ui(f: &mut Frame, app: &mut App) {
+    render_board(f, app);
+    match app.current_view {
+        View::TaskDescription => render_task_description(f, app),
+        View::AssignAgent => render_assign_agent(f, app),
+        View::AddComment => render_add_comment(f, app),
+        View::AddTask => render_add_task(f, app),
+        View::UpdateTask => render_update_task(f, app),
+        View::Logs => render_logs(f, app),
+        View::Agents => render_agents_list(f, app),
+        View::Okrs => render_okrs(f, app),
+        View::Commands => render_commands(f),
+        _ => {}
+    }
+}
+
+fn render_board(f: &mut Frame, app: &mut App) {
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints(
+            [
+                Constraint::Percentage(33),
+                Constraint::Percentage(33),
+                Constraint::Percentage(34),
+            ]
+            .as_ref(),
+        )
+        .split(f.area());
+
+    for (i, status) in [TaskStatus::ToDo, TaskStatus::InProgress, TaskStatus::Done]
+        .iter()
+        .enumerate()
+    {
+        let tasks: Vec<ListItem> = app
+            .board
+            .lock()
+            .unwrap()
+            .tasks
+            .iter()
+            .filter(|t| t.status == *status)
+            .map(|t| {
+                let title = if t.agent_id.is_some() {
+                    format!("* {}", t.title)
+                } else {
+                    t.title.clone()
+                };
+                ListItem::new(title)
+            })
+            .collect();
+        let mut list = List::new(tasks).block(
+            Block::default()
+                .title(format!("{status:?}"))
+                .borders(Borders::ALL),
+        );
+        if app.selected_column == i {
+            list = list.highlight_style(
+                Style::default()
+                    .add_modifier(Modifier::BOLD)
+                    .bg(Color::Blue),
+            );
+        }
+        f.render_stateful_widget(list, chunks[i], &mut app.selected_task[i]);
+    }
+}
+
+fn render_task_description(f: &mut Frame, app: &mut App) {
+    if let Some(task) = app.get_selected_task() {
+        let mut text = vec![
+            Line::from(Span::styled(
+                task.title.clone(),
+                Style::default().add_modifier(Modifier::BOLD),
+            )),
+            Line::from(task.description.clone().unwrap_or_default()),
+        ];
+
+        if let Some(agent_id) = task.agent_id {
+            text.push(Line::from(format!("Assigned to agent: {agent_id}")));
+        }
+
+        if let Some(comment) = &task.comment {
+            text.push(Line::from(Span::styled(
+                format!("Comment: {comment}"),
+                Style::default().fg(Color::Yellow),
+            )));
+        }
+
+        let block = Block::default()
+            .title("Task Description")
+            .borders(Borders::ALL);
+        let paragraph = Paragraph::new(text).block(block).wrap(Wrap { trim: true });
+        let area = centered_rect(60, 25, f.area());
+        f.render_widget(Clear, area);
+        f.render_widget(paragraph, area);
+    }
+}
+
+fn render_assign_agent(f: &mut Frame, app: &mut App) {
+    if app.agents.is_empty() {
+        let block = Block::default().title("Assign Agent").borders(Borders::ALL);
+        let text = Paragraph::new("No agents available. Create one with `taskter add-agent`")
+            .block(block)
+            .wrap(Wrap { trim: true });
+        let area = centered_rect(60, 25, f.area());
+        f.render_widget(Clear, area);
+        f.render_widget(text, area);
+        return;
+    }
+
+    let agents: Vec<ListItem> = app
+        .agents
+        .iter()
+        .map(|a| ListItem::new(a.system_prompt.as_str()))
+        .collect();
+
+    let agent_list = List::new(agents)
+        .block(Block::default().title("Assign Agent").borders(Borders::ALL))
+        .highlight_style(
+            Style::default()
+                .add_modifier(Modifier::BOLD)
+                .bg(Color::Blue),
+        );
+
+    let area = centered_rect(60, 25, f.area());
+    f.render_widget(Clear, area);
+    f.render_stateful_widget(agent_list, area, &mut app.agent_list_state);
+}
+
+fn render_add_comment(f: &mut Frame, app: &mut App) {
+    let block = Block::default().title("Add Comment").borders(Borders::ALL);
+    let paragraph = Paragraph::new(app.comment_input.as_str())
+        .block(block)
+        .wrap(Wrap { trim: true });
+    let area = centered_rect(60, 25, f.area());
+    f.render_widget(Clear, area);
+    f.render_widget(paragraph, area);
+}
+
+fn render_add_task(f: &mut Frame, app: &mut App) {
+    let block = Block::default().title("New Task").borders(Borders::ALL);
+    let title_style = if !app.editing_description {
+        Style::default().fg(Color::Yellow)
+    } else {
+        Style::default()
+    };
+    let desc_style = if app.editing_description {
+        Style::default().fg(Color::Yellow)
+    } else {
+        Style::default()
+    };
+    let paragraph = Paragraph::new(vec![
+        Line::from(vec![
+            Span::raw("Title: "),
+            Span::styled(app.new_task_title.as_str(), title_style),
+        ]),
+        Line::from(vec![
+            Span::raw("Description: "),
+            Span::styled(app.new_task_description.as_str(), desc_style),
+        ]),
+    ])
+    .block(block)
+    .wrap(Wrap { trim: true });
+    let area = centered_rect(60, 15, f.area());
+    f.render_widget(Clear, area);
+    f.render_widget(paragraph, area);
+}
+
+fn render_update_task(f: &mut Frame, app: &mut App) {
+    let block = Block::default().title("Edit Task").borders(Borders::ALL);
+    let title_style = if !app.editing_description {
+        Style::default().fg(Color::Yellow)
+    } else {
+        Style::default()
+    };
+    let desc_style = if app.editing_description {
+        Style::default().fg(Color::Yellow)
+    } else {
+        Style::default()
+    };
+    let paragraph = Paragraph::new(vec![
+        Line::from(vec![
+            Span::raw("Title: "),
+            Span::styled(app.new_task_title.as_str(), title_style),
+        ]),
+        Line::from(vec![
+            Span::raw("Description: "),
+            Span::styled(app.new_task_description.as_str(), desc_style),
+        ]),
+    ])
+    .block(block)
+    .wrap(Wrap { trim: true });
+    let area = centered_rect(60, 15, f.area());
+    f.render_widget(Clear, area);
+    f.render_widget(paragraph, area);
+}
+
+fn render_logs(f: &mut Frame, app: &mut App) {
+    let block = Block::default().title("Logs").borders(Borders::ALL);
+    let paragraph = Paragraph::new(app.logs.as_str())
+        .block(block)
+        .wrap(Wrap { trim: true });
+    let area = centered_rect(60, 50, f.area());
+    f.render_widget(Clear, area);
+    f.render_widget(paragraph, area);
+}
+
+fn render_agents_list(f: &mut Frame, app: &mut App) {
+    let items: Vec<ListItem> = app
+        .agents
+        .iter()
+        .map(|a| ListItem::new(format!("{}: {}", a.id, a.system_prompt)))
+        .collect();
+    let list = List::new(items).block(Block::default().title("Agents").borders(Borders::ALL));
+    let area = centered_rect(60, 25, f.area());
+    f.render_widget(Clear, area);
+    f.render_widget(list, area);
+}
+
+fn render_okrs(f: &mut Frame, app: &mut App) {
+    let mut lines = Vec::new();
+    for okr in &app.okrs {
+        lines.push(Line::from(Span::styled(
+            &okr.objective,
+            Style::default().add_modifier(Modifier::BOLD),
+        )));
+        for kr in &okr.key_results {
+            lines.push(Line::from(format!(
+                " - {} ({:.0}%)",
+                kr.name,
+                kr.progress * 100.0
+            )));
+        }
+        lines.push(Line::raw(""));
+    }
+    let block = Block::default().title("OKRs").borders(Borders::ALL);
+    let paragraph = Paragraph::new(lines).block(block).wrap(Wrap { trim: true });
+    let area = centered_rect(60, 50, f.area());
+    f.render_widget(Clear, area);
+    f.render_widget(paragraph, area);
+}
+
+fn render_commands(f: &mut Frame) {
+    let lines = vec![
+        Line::from("q - Quit"),
+        Line::from("←/→ or Tab - Switch columns"),
+        Line::from("↑/↓ - Navigate tasks"),
+        Line::from("h/l - Move task"),
+        Line::from("n - New task"),
+        Line::from("u - Edit task"),
+        Line::from("d - Delete task"),
+        Line::from("a - Assign agent"),
+        Line::from("c - Add comment"),
+        Line::from("L - View logs"),
+        Line::from("A - List agents"),
+        Line::from("O - Show OKRs"),
+    ];
+    let block = Block::default().title("Commands").borders(Borders::ALL);
+    let paragraph = Paragraph::new(lines).block(block).wrap(Wrap { trim: true });
+    let area = centered_rect(60, 50, f.area());
+    f.render_widget(Clear, area);
+    f.render_widget(paragraph, area);
+}
+
+/// helper function to create a centered rect using up certain percentage of the available rect `r`
+fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
+    let popup_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(r);
+
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(popup_layout[1])[1]
+}


### PR DESCRIPTION
## Summary
- organize TUI implementation into `src/tui/` directory
- split TUI code into `app`, `handlers`, and `render` modules
- re-export `run_tui` from `tui::mod`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687d90b019088320a7b5b79a59633387