### PR TITLE
Add update-agent command

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -251,3 +251,17 @@ pub fn delete_agent(id: usize) -> anyhow::Result<()> {
     }
     Ok(())
 }
+
+pub fn update_agent(
+    id: usize,
+    prompt: String,
+    tools: Vec<FunctionDeclaration>,
+) -> anyhow::Result<()> {
+    let mut agents = load_agents()?;
+    if let Some(agent) = agents.iter_mut().find(|a| a.id == id) {
+        agent.system_prompt = prompt;
+        agent.tools = tools;
+        save_agents(&agents)?;
+    }
+    Ok(())
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -97,6 +97,19 @@ pub enum Commands {
         #[arg(short, long)]
         agent_id: usize,
     },
+    /// Updates an agent's prompt and tools
+    #[command(name = "update-agent")]
+    UpdateAgent {
+        /// The id of the agent to update
+        #[arg(short = 'i', long)]
+        agent_id: usize,
+        /// The new system prompt for the agent
+        #[arg(short, long)]
+        prompt: String,
+        /// The new tools the agent can use
+        #[arg(short, long, num_args = 1..)]
+        tools: Vec<String>,
+    },
 }
 
 #[derive(Subcommand)]


### PR DESCRIPTION
## Summary
- add `update_agent` helper to modify stored agents
- support `update-agent` CLI command
- handle new command in the application
- test agent updates in CLI tests

## Testing
- `./scripts/precommit.sh`

------
https://chatgpt.com/codex/tasks/task_e_687d908b2d8483209fda48b978fb4fe6