### PR TITLE
Add config module for .taskter paths

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -8,7 +8,8 @@ use serde_json::{json, Value};
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
-use std::path::Path;
+
+use crate::config;
 
 #[derive(Debug, PartialEq)]
 pub enum ExecutionResult {
@@ -20,7 +21,7 @@ fn append_log(message: &str) -> Result<()> {
     let mut file = OpenOptions::new()
         .create(true)
         .append(true)
-        .open(".taskter/logs.log")?;
+        .open(config::logs_file())?;
     let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S");
     writeln!(file, "[{timestamp}] {message}")?;
     Ok(())
@@ -221,21 +222,21 @@ pub struct Agent {
 }
 
 pub fn load_agents() -> anyhow::Result<Vec<Agent>> {
-    let path = Path::new(".taskter/agents.json");
+    let path = config::agents_file();
     if !path.exists() {
         fs::create_dir_all(path.parent().unwrap())?;
-        fs::write(path, "[]")?;
+        fs::write(&path, "[]")?;
     }
 
-    let content = fs::read_to_string(path)?;
+    let content = fs::read_to_string(&path)?;
     let agents: Vec<Agent> = serde_json::from_str(&content)?;
     Ok(agents)
 }
 
 pub fn save_agents(agents: &[Agent]) -> anyhow::Result<()> {
-    let path = Path::new(".taskter/agents.json");
+    let path = config::agents_file();
     let content = serde_json::to_string_pretty(agents)?;
-    fs::write(path, content)?;
+    fs::write(&path, content)?;
     Ok(())
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,33 @@
+use std::path::{Path, PathBuf};
+
+/// Root directory for all Taskter state.
+pub const TASKTER_DIR: &str = ".taskter";
+
+/// Return the path to a file inside the `.taskter` directory.
+pub fn path(file: &str) -> PathBuf {
+    Path::new(TASKTER_DIR).join(file)
+}
+
+pub fn board_file() -> PathBuf {
+    path("board.json")
+}
+
+pub fn okrs_file() -> PathBuf {
+    path("okrs.json")
+}
+
+pub fn agents_file() -> PathBuf {
+    path("agents.json")
+}
+
+pub fn logs_file() -> PathBuf {
+    path("logs.log")
+}
+
+pub fn description_file() -> PathBuf {
+    path("description.md")
+}
+
+pub fn email_config_file() -> PathBuf {
+    path("email_config.json")
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod agent;
 pub mod cli;
+pub mod config;
 pub mod store;
 pub mod tools;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 
 use taskter::cli::*;
 mod agent;
+mod config;
 mod store;
 mod tools;
 mod tui;
@@ -16,7 +17,7 @@ async fn main() -> anyhow::Result<()> {
 
     match &cli.command {
         Commands::Init => {
-            let path = Path::new(".taskter");
+            let path = Path::new(config::TASKTER_DIR);
             if path.exists() {
                 println!("Taskter board already initialized.");
             } else {
@@ -77,15 +78,15 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Show { what } => match what {
             ShowCommands::Description => {
-                let description = fs::read_to_string(".taskter/description.md")?;
+                let description = fs::read_to_string(config::description_file())?;
                 println!("{description}");
             }
             ShowCommands::Okrs => {
-                let okrs = fs::read_to_string(".taskter/okrs.json")?;
+                let okrs = fs::read_to_string(config::okrs_file())?;
                 println!("{okrs}");
             }
             ShowCommands::Logs => {
-                let logs = fs::read_to_string(".taskter/logs.log")?;
+                let logs = fs::read_to_string(config::logs_file())?;
                 println!("{logs}");
             }
             ShowCommands::Agents => {
@@ -123,7 +124,7 @@ async fn main() -> anyhow::Result<()> {
             let mut file = fs::OpenOptions::new()
                 .create(true)
                 .append(true)
-                .open(".taskter/logs.log")?;
+                .open(config::logs_file())?;
             let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S");
             writeln!(file, "[{timestamp}] {message}")?;
             println!("Log added successfully.");
@@ -132,7 +133,7 @@ async fn main() -> anyhow::Result<()> {
             tui::run_tui()?;
         }
         Commands::Description { description } => {
-            fs::write(".taskter/description.md", description)?;
+            fs::write(config::description_file(), description)?;
             println!("Project description updated successfully.");
         }
         Commands::AddAgent {

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::Path;
+
+use crate::config;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum TaskStatus {
@@ -37,7 +38,7 @@ pub struct Okr {
 }
 
 pub fn load_board() -> anyhow::Result<Board> {
-    let path = Path::new(".taskter/board.json");
+    let path = config::board_file();
     if !path.exists() {
         return Ok(Board::default());
     }
@@ -48,14 +49,14 @@ pub fn load_board() -> anyhow::Result<Board> {
 }
 
 pub fn save_board(board: &Board) -> anyhow::Result<()> {
-    let path = Path::new(".taskter/board.json");
+    let path = config::board_file();
     let content = serde_json::to_string_pretty(board)?;
     fs::write(path, content)?;
     Ok(())
 }
 
 pub fn load_okrs() -> anyhow::Result<Vec<Okr>> {
-    let path = Path::new(".taskter/okrs.json");
+    let path = config::okrs_file();
     if !path.exists() {
         return Ok(Vec::new());
     }
@@ -66,7 +67,7 @@ pub fn load_okrs() -> anyhow::Result<Vec<Okr>> {
 }
 
 pub fn save_okrs(okrs: &[Okr]) -> anyhow::Result<()> {
-    let path = Path::new(".taskter/okrs.json");
+    let path = config::okrs_file();
     let content = serde_json::to_string_pretty(okrs)?;
     fs::write(path, content)?;
     Ok(())

--- a/src/tools/add_log.rs
+++ b/src/tools/add_log.rs
@@ -5,6 +5,7 @@ use std::fs::OpenOptions;
 use std::io::Write;
 
 use crate::agent::FunctionDeclaration;
+use crate::config;
 
 const DECL_JSON: &str = include_str!("../../tools/add_log.json");
 
@@ -19,7 +20,7 @@ pub fn execute(args: &Value) -> Result<String> {
     let mut file = OpenOptions::new()
         .create(true)
         .append(true)
-        .open(".taskter/logs.log")?;
+        .open(config::logs_file())?;
     let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S");
     writeln!(file, "[{timestamp}] {message}")?;
     Ok("Log entry added".to_string())

--- a/src/tools/email.rs
+++ b/src/tools/email.rs
@@ -3,9 +3,9 @@ use lettre::{transport::smtp::authentication::Credentials, Message, SmtpTranspor
 use serde::Deserialize;
 use serde_json::Value;
 use std::fs;
-use std::path::Path;
 
 use crate::agent::FunctionDeclaration;
+use crate::config;
 
 #[derive(Deserialize)]
 struct EmailConfig {
@@ -34,8 +34,8 @@ pub fn execute(args: &Value) -> Result<String> {
 }
 
 fn send_email(to: &str, subject: &str, body: &str) -> Result<()> {
-    let config_path = Path::new(".taskter/email_config.json");
-    let config_str = match fs::read_to_string(config_path) {
+    let config_path = config::email_config_file();
+    let config_str = match fs::read_to_string(&config_path) {
         Ok(content) => content,
         Err(_) => return Err(anyhow::anyhow!("Email configuration not found")),
     };

--- a/src/tools/get_description.rs
+++ b/src/tools/get_description.rs
@@ -3,6 +3,7 @@ use serde_json::Value;
 use std::fs;
 
 use crate::agent::FunctionDeclaration;
+use crate::config;
 
 const DECL_JSON: &str = include_str!("../../tools/get_description.json");
 
@@ -11,6 +12,6 @@ pub fn declaration() -> FunctionDeclaration {
 }
 
 pub fn execute(_args: &Value) -> Result<String> {
-    let content = fs::read_to_string(".taskter/description.md")?;
+    let content = fs::read_to_string(config::description_file())?;
     Ok(content)
 }

--- a/tests/cli_commands.rs
+++ b/tests/cli_commands.rs
@@ -2,6 +2,7 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use serde_json::Value;
 use std::fs;
+use taskter::config;
 
 fn with_temp_dir<F: FnOnce() -> T, T>(test: F) -> T {
     let tmp = tempfile::tempdir().expect("failed to create temp dir");
@@ -54,7 +55,7 @@ fn add_list_done_workflow() {
 
         // Inspect board file
         let board: Value =
-            serde_json::from_str(&fs::read_to_string(".taskter/board.json").unwrap()).unwrap();
+            serde_json::from_str(&fs::read_to_string(config::board_file()).unwrap()).unwrap();
         assert_eq!(board["tasks"][0]["status"], "Done");
     });
 }
@@ -106,7 +107,7 @@ fn add_agent_and_execute_task() {
             .success();
 
         let board: Value =
-            serde_json::from_str(&fs::read_to_string(".taskter/board.json").unwrap()).unwrap();
+            serde_json::from_str(&fs::read_to_string(config::board_file()).unwrap()).unwrap();
         assert_eq!(board["tasks"][0]["status"], "Done");
     });
 }
@@ -155,7 +156,7 @@ fn list_and_delete_agents() {
             .stdout(predicate::str::contains("Agent 1 deleted."));
 
         let agents: Vec<Value> =
-            serde_json::from_str(&fs::read_to_string(".taskter/agents.json").unwrap()).unwrap();
+            serde_json::from_str(&fs::read_to_string(config::agents_file()).unwrap()).unwrap();
         assert!(agents.is_empty());
     });
 }
@@ -178,7 +179,7 @@ fn add_okr_log_and_description() {
             .stdout(predicate::str::contains("OKR added successfully"));
 
         let okrs: Value =
-            serde_json::from_str(&fs::read_to_string(".taskter/okrs.json").unwrap()).unwrap();
+            serde_json::from_str(&fs::read_to_string(config::okrs_file()).unwrap()).unwrap();
         assert_eq!(okrs.as_array().unwrap().len(), 1);
         assert_eq!(okrs[0]["objective"], "Improve UI");
 
@@ -190,7 +191,7 @@ fn add_okr_log_and_description() {
             .success()
             .stdout(predicate::str::contains("Log added successfully"));
 
-        let logs = fs::read_to_string(".taskter/logs.log").unwrap();
+        let logs = fs::read_to_string(config::logs_file()).unwrap();
         assert!(logs.contains("Initial commit"));
 
         // update description
@@ -203,7 +204,7 @@ fn add_okr_log_and_description() {
                 "Project description updated successfully",
             ));
 
-        let desc = fs::read_to_string(".taskter/description.md").unwrap();
+        let desc = fs::read_to_string(config::description_file()).unwrap();
         assert_eq!(desc, "A great project");
     });
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2,6 +2,7 @@ use std::fs;
 
 use serde_json::json;
 use taskter::agent::{self, Agent, ExecutionResult, FunctionDeclaration};
+use taskter::config;
 use taskter::store::{self, Board, KeyResult, Okr, Task, TaskStatus};
 
 // Helper that creates a temporary workspace and changes the current directory to it.
@@ -11,7 +12,7 @@ fn with_temp_dir<F: FnOnce() -> T, T>(test: F) -> T {
     std::env::set_current_dir(tmp.path()).expect("cannot set current dir");
 
     // Each Taskter invocation expects the .taskter directory to exist. We'll ensure it's present.
-    fs::create_dir(".taskter").unwrap();
+    fs::create_dir(config::TASKTER_DIR).unwrap();
 
     let result = test();
 

--- a/tests/tool_functions.rs
+++ b/tests/tool_functions.rs
@@ -2,6 +2,7 @@ use serde_json::json;
 use std::fs;
 
 use taskter::agent::{self, Agent};
+use taskter::config;
 use taskter::store::{self, Board, Task, TaskStatus};
 use taskter::tools::{
     add_log, add_okr, assign_agent, create_task, get_description, list_agents, list_tasks,
@@ -12,7 +13,7 @@ fn with_temp_dir<F: FnOnce() -> T, T>(test: F) -> T {
     let original_dir = std::env::current_dir().expect("cannot read current dir");
     std::env::set_current_dir(tmp.path()).expect("cannot set current dir");
 
-    fs::create_dir(".taskter").unwrap();
+    fs::create_dir(config::TASKTER_DIR).unwrap();
 
     let result = test();
 
@@ -138,7 +139,7 @@ fn add_okr_requires_fields() {
 fn add_log_appends_message() {
     with_temp_dir(|| {
         add_log::execute(&json!({"message":"hello"})).unwrap();
-        let content = fs::read_to_string(".taskter/logs.log").unwrap();
+        let content = fs::read_to_string(config::logs_file()).unwrap();
         assert!(content.contains("hello"));
     });
 }
@@ -207,7 +208,7 @@ fn list_tasks_empty_when_none() {
 #[test]
 fn get_description_reads_file() {
     with_temp_dir(|| {
-        fs::write(".taskter/description.md", "desc").unwrap();
+        fs::write(config::description_file(), "desc").unwrap();
         let out = get_description::execute(&json!({})).unwrap();
         assert_eq!(out, "desc");
     });


### PR DESCRIPTION
## Summary
- centralize `.taskter` paths in a new `config` module
- use config helpers in store, agent, main and tool modules
- update tests to reference the config module

## Testing
- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687d90a07f048320b4768c9e85c3c629