### PR TITLE
Add tests for TUI and tool failures

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -820,3 +820,67 @@ fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
         ])
         .split(popup_layout[1])[1]
 }
+
+#[cfg(all(test, feature = "tui"))]
+mod tests {
+    use super::*;
+    use crate::store::{Board, Task, TaskStatus};
+
+    fn sample_app() -> App {
+        let board = Board {
+            tasks: vec![
+                Task {
+                    id: 1,
+                    title: "t1".into(),
+                    description: None,
+                    status: TaskStatus::ToDo,
+                    agent_id: None,
+                    comment: None,
+                },
+                Task {
+                    id: 2,
+                    title: "t2".into(),
+                    description: None,
+                    status: TaskStatus::ToDo,
+                    agent_id: None,
+                    comment: None,
+                },
+            ],
+        };
+        App::new(board, vec![])
+    }
+
+    #[test]
+    fn column_navigation_wraps() {
+        let mut app = sample_app();
+        assert_eq!(app.selected_column, 0);
+        app.next_column();
+        assert_eq!(app.selected_column, 1);
+        app.next_column();
+        assert_eq!(app.selected_column, 2);
+        app.next_column();
+        assert_eq!(app.selected_column, 0);
+        app.prev_column();
+        assert_eq!(app.selected_column, 2);
+    }
+
+    #[test]
+    fn task_navigation_cycles() {
+        let mut app = sample_app();
+        assert_eq!(app.selected_task[0].selected(), Some(0));
+        app.next_task();
+        assert_eq!(app.selected_task[0].selected(), Some(1));
+        app.next_task();
+        assert_eq!(app.selected_task[0].selected(), Some(0));
+        app.prev_task();
+        assert_eq!(app.selected_task[0].selected(), Some(1));
+    }
+
+    #[test]
+    fn moving_task_updates_status() {
+        let mut app = sample_app();
+        app.move_task_to_next_column();
+        let board = app.board.lock().unwrap();
+        assert_eq!(board.tasks[0].status, TaskStatus::InProgress);
+    }
+}

--- a/tests/tool_functions.rs
+++ b/tests/tool_functions.rs
@@ -5,6 +5,7 @@ use taskter::agent::{self, Agent};
 use taskter::store::{self, Board, Task, TaskStatus};
 use taskter::tools::{
     add_log, add_okr, assign_agent, create_task, get_description, list_agents, list_tasks,
+    run_bash, run_python,
 };
 
 fn with_temp_dir<F: FnOnce() -> T, T>(test: F) -> T {
@@ -218,5 +219,38 @@ fn get_description_fails_missing_file() {
     with_temp_dir(|| {
         let err = get_description::execute(&json!({})).unwrap_err();
         assert!(err.to_string().contains("No such file"));
+    });
+}
+
+#[test]
+fn run_bash_requires_command() {
+    with_temp_dir(|| {
+        let err = run_bash::execute(&json!({})).unwrap_err();
+        assert!(err.to_string().contains("command missing"));
+    });
+}
+
+#[test]
+fn run_bash_fails_on_error() {
+    with_temp_dir(|| {
+        let err = run_bash::execute(&json!({"command": "false"})).unwrap_err();
+        assert!(err.to_string().contains("Command failed"));
+    });
+}
+
+#[test]
+fn run_python_requires_code() {
+    with_temp_dir(|| {
+        let err = run_python::execute(&json!({})).unwrap_err();
+        assert!(err.to_string().contains("code missing"));
+    });
+}
+
+#[test]
+fn run_python_fails_on_error() {
+    with_temp_dir(|| {
+        let err = run_python::execute(&json!({"code": "raise Exception()"}))
+            .unwrap_err();
+        assert!(err.to_string().contains("Python execution failed"));
     });
 }


### PR DESCRIPTION
## Summary
- cover TUI logic with internal unit tests
- add failure cases for `run_bash` and `run_python`

## Testing
- `cargo test --all-features`

------
https://chatgpt.com/codex/tasks/task_e_687d91d4a84c8320a312b10eb1e409e6