### PR TITLE
Add Board methods and use them

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,15 +31,7 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Add { title, description } => {
             let mut board = store::load_board()?;
-            let new_task = store::Task {
-                id: board.tasks.len() + 1,
-                title: title.clone(),
-                description: description.clone(),
-                status: store::TaskStatus::ToDo,
-                agent_id: None,
-                comment: None,
-            };
-            board.tasks.push(new_task);
+            board.add_task(title.clone(), description.clone());
             store::save_board(&board)?;
             println!("Task added successfully.");
         }
@@ -57,8 +49,7 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Done { id } => {
             let mut board = store::load_board()?;
-            if let Some(task) = board.tasks.iter_mut().find(|t| t.id == *id) {
-                task.status = store::TaskStatus::Done;
+            if board.mark_done(*id) {
                 store::save_board(&board)?;
                 println!("Task {id} marked as done.");
             } else {
@@ -67,8 +58,7 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Comment { task_id, comment } => {
             let mut board = store::load_board()?;
-            if let Some(task) = board.tasks.iter_mut().find(|t| t.id == *task_id) {
-                task.comment = Some(comment.clone());
+            if board.add_comment(*task_id, comment.clone()) {
                 store::save_board(&board)?;
                 println!("Comment added to task {task_id}.");
             } else {
@@ -204,8 +194,7 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Assign { task_id, agent_id } => {
             let mut board = store::load_board()?;
-            if let Some(task) = board.tasks.iter_mut().find(|t| t.id == *task_id) {
-                task.agent_id = Some(*agent_id);
+            if board.assign_agent(*task_id, *agent_id) {
                 store::save_board(&board)?;
                 println!("Agent {agent_id} assigned to task {task_id}.");
             } else {

--- a/src/store.rs
+++ b/src/store.rs
@@ -24,6 +24,69 @@ pub struct Board {
     pub tasks: Vec<Task>,
 }
 
+impl Board {
+    fn next_id(&self) -> usize {
+        self.tasks.iter().map(|t| t.id).max().unwrap_or(0) + 1
+    }
+
+    pub fn add_task(&mut self, title: String, description: Option<String>) -> usize {
+        let id = self.next_id();
+        let task = Task {
+            id,
+            title,
+            description,
+            status: TaskStatus::ToDo,
+            agent_id: None,
+            comment: None,
+        };
+        self.tasks.push(task);
+        id
+    }
+
+    pub fn mark_done(&mut self, id: usize) -> bool {
+        if let Some(task) = self.tasks.iter_mut().find(|t| t.id == id) {
+            task.status = TaskStatus::Done;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn assign_agent(&mut self, task_id: usize, agent_id: usize) -> bool {
+        if let Some(task) = self.tasks.iter_mut().find(|t| t.id == task_id) {
+            task.agent_id = Some(agent_id);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn add_comment(&mut self, task_id: usize, comment: String) -> bool {
+        if let Some(task) = self.tasks.iter_mut().find(|t| t.id == task_id) {
+            task.comment = Some(comment);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn update_task(&mut self, id: usize, title: String, description: Option<String>) -> bool {
+        if let Some(task) = self.tasks.iter_mut().find(|t| t.id == id) {
+            task.title = title;
+            task.description = description;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn remove_task(&mut self, id: usize) -> bool {
+        let initial = self.tasks.len();
+        self.tasks.retain(|t| t.id != id);
+        initial != self.tasks.len()
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct KeyResult {
     pub name: String,

--- a/src/tools/assign_agent.rs
+++ b/src/tools/assign_agent.rs
@@ -24,8 +24,7 @@ pub fn execute(args: &Value) -> Result<String> {
     }
 
     let mut board = store::load_board()?;
-    if let Some(task) = board.tasks.iter_mut().find(|t| t.id == task_id) {
-        task.agent_id = Some(agent_id);
+    if board.assign_agent(task_id, agent_id) {
         store::save_board(&board)?;
         Ok(format!("Agent {agent_id} assigned to task {task_id}"))
     } else {

--- a/src/tools/create_task.rs
+++ b/src/tools/create_task.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use serde_json::Value;
 
 use crate::agent::FunctionDeclaration;
-use crate::store::{self, Task, TaskStatus};
+use crate::store;
 
 const DECL_JSON: &str = include_str!("../../tools/create_task.json");
 
@@ -20,16 +20,7 @@ pub fn execute(args: &Value) -> Result<String> {
         .map(String::from);
 
     let mut board = store::load_board()?;
-    let id = board.tasks.len() + 1;
-    let task = Task {
-        id,
-        title: title.to_string(),
-        description,
-        status: TaskStatus::ToDo,
-        agent_id: None,
-        comment: None,
-    };
-    board.tasks.push(task);
+    let id = board.add_task(title.to_string(), description);
     store::save_board(&board)?;
     Ok(format!("Created task {id}"))
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -83,7 +83,7 @@ fn comment_roundtrip_persists_changes() {
 
         store::save_board(&board).expect("failed to save board");
 
-        board.tasks[0].comment = Some("note".to_string());
+        board.add_comment(1, "note".to_string());
         store::save_board(&board).expect("failed to save board");
 
         let loaded = store::load_board().expect("failed to load board");


### PR DESCRIPTION
## Summary
- expose board manipulation helpers (`add_task`, `mark_done`, `assign_agent`, etc.)
- update CLI, tools and TUI to use the new API
- adjust integration tests for the board API

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687d90cdb3cc8320a4cf158afd752fa3