### PR TITLE
Refactor built‑in tool registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1991,6 +1991,7 @@ dependencies = [
  "lettre",
  "mockito",
  "notify",
+ "once_cell",
  "predicates",
  "ratatui",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ tokio = { version = "1.37.0", features = ["full"] }
 lettre = "0.11.17"
 chrono = { version = "0.4", features = ["serde"] }
 notify = "8.1"
+once_cell = "1.19"
 [features]
 tui = []
 [dev-dependencies]

--- a/src/tools/add_log.rs
+++ b/src/tools/add_log.rs
@@ -5,6 +5,8 @@ use std::fs::OpenOptions;
 use std::io::Write;
 
 use crate::agent::FunctionDeclaration;
+use crate::tools::Tool;
+use std::collections::HashMap;
 
 const DECL_JSON: &str = include_str!("../../tools/add_log.json");
 
@@ -23,4 +25,14 @@ pub fn execute(args: &Value) -> Result<String> {
     let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S");
     writeln!(file, "[{timestamp}] {message}")?;
     Ok("Log entry added".to_string())
+}
+
+pub fn register(map: &mut HashMap<&'static str, Tool>) {
+    map.insert(
+        "add_log",
+        Tool {
+            declaration: declaration(),
+            execute,
+        },
+    );
 }

--- a/src/tools/add_okr.rs
+++ b/src/tools/add_okr.rs
@@ -3,6 +3,8 @@ use serde_json::Value;
 
 use crate::agent::FunctionDeclaration;
 use crate::store::{self, KeyResult, Okr};
+use crate::tools::Tool;
+use std::collections::HashMap;
 
 const DECL_JSON: &str = include_str!("../../tools/add_okr.json");
 
@@ -35,4 +37,14 @@ pub fn execute(args: &Value) -> Result<String> {
     });
     store::save_okrs(&okrs)?;
     Ok(format!("Added OKR '{objective}'"))
+}
+
+pub fn register(map: &mut HashMap<&'static str, Tool>) {
+    map.insert(
+        "add_okr",
+        Tool {
+            declaration: declaration(),
+            execute,
+        },
+    );
 }

--- a/src/tools/assign_agent.rs
+++ b/src/tools/assign_agent.rs
@@ -3,6 +3,8 @@ use serde_json::Value;
 
 use crate::agent::{self, FunctionDeclaration};
 use crate::store;
+use crate::tools::Tool;
+use std::collections::HashMap;
 
 const DECL_JSON: &str = include_str!("../../tools/assign_agent.json");
 
@@ -31,4 +33,14 @@ pub fn execute(args: &Value) -> Result<String> {
     } else {
         Ok(format!("Task {task_id} not found"))
     }
+}
+
+pub fn register(map: &mut HashMap<&'static str, Tool>) {
+    map.insert(
+        "assign_agent",
+        Tool {
+            declaration: declaration(),
+            execute,
+        },
+    );
 }

--- a/src/tools/create_task.rs
+++ b/src/tools/create_task.rs
@@ -3,6 +3,8 @@ use serde_json::Value;
 
 use crate::agent::FunctionDeclaration;
 use crate::store::{self, Task, TaskStatus};
+use crate::tools::Tool;
+use std::collections::HashMap;
 
 const DECL_JSON: &str = include_str!("../../tools/create_task.json");
 
@@ -32,4 +34,14 @@ pub fn execute(args: &Value) -> Result<String> {
     board.tasks.push(task);
     store::save_board(&board)?;
     Ok(format!("Created task {id}"))
+}
+
+pub fn register(map: &mut HashMap<&'static str, Tool>) {
+    map.insert(
+        "create_task",
+        Tool {
+            declaration: declaration(),
+            execute,
+        },
+    );
 }

--- a/src/tools/email.rs
+++ b/src/tools/email.rs
@@ -6,6 +6,8 @@ use std::fs;
 use std::path::Path;
 
 use crate::agent::FunctionDeclaration;
+use crate::tools::Tool;
+use std::collections::HashMap;
 
 #[derive(Deserialize)]
 struct EmailConfig {
@@ -56,4 +58,22 @@ fn send_email(to: &str, subject: &str, body: &str) -> Result<()> {
         .build();
 
     mailer.send(&email).map(|_| ()).map_err(|e| e.into())
+}
+
+pub fn register(map: &mut HashMap<&'static str, Tool>) {
+    let decl = declaration();
+    map.insert(
+        "send_email",
+        Tool {
+            declaration: decl.clone(),
+            execute,
+        },
+    );
+    map.insert(
+        "email",
+        Tool {
+            declaration: decl,
+            execute,
+        },
+    );
 }

--- a/src/tools/get_description.rs
+++ b/src/tools/get_description.rs
@@ -3,6 +3,8 @@ use serde_json::Value;
 use std::fs;
 
 use crate::agent::FunctionDeclaration;
+use crate::tools::Tool;
+use std::collections::HashMap;
 
 const DECL_JSON: &str = include_str!("../../tools/get_description.json");
 
@@ -13,4 +15,14 @@ pub fn declaration() -> FunctionDeclaration {
 pub fn execute(_args: &Value) -> Result<String> {
     let content = fs::read_to_string(".taskter/description.md")?;
     Ok(content)
+}
+
+pub fn register(map: &mut HashMap<&'static str, Tool>) {
+    map.insert(
+        "get_description",
+        Tool {
+            declaration: declaration(),
+            execute,
+        },
+    );
 }

--- a/src/tools/list_agents.rs
+++ b/src/tools/list_agents.rs
@@ -2,6 +2,8 @@ use anyhow::Result;
 use serde_json::Value;
 
 use crate::agent::{self, FunctionDeclaration};
+use crate::tools::Tool;
+use std::collections::HashMap;
 
 const DECL_JSON: &str = include_str!("../../tools/list_agents.json");
 
@@ -12,4 +14,14 @@ pub fn declaration() -> FunctionDeclaration {
 pub fn execute(_args: &Value) -> Result<String> {
     let agents = agent::list_agents()?;
     Ok(serde_json::to_string_pretty(&agents)?)
+}
+
+pub fn register(map: &mut HashMap<&'static str, Tool>) {
+    map.insert(
+        "list_agents",
+        Tool {
+            declaration: declaration(),
+            execute,
+        },
+    );
 }

--- a/src/tools/list_tasks.rs
+++ b/src/tools/list_tasks.rs
@@ -3,6 +3,8 @@ use serde_json::Value;
 
 use crate::agent::FunctionDeclaration;
 use crate::store;
+use crate::tools::Tool;
+use std::collections::HashMap;
 
 const DECL_JSON: &str = include_str!("../../tools/list_tasks.json");
 
@@ -13,4 +15,14 @@ pub fn declaration() -> FunctionDeclaration {
 pub fn execute(_args: &Value) -> Result<String> {
     let board = store::load_board()?;
     Ok(serde_json::to_string_pretty(&board.tasks)?)
+}
+
+pub fn register(map: &mut HashMap<&'static str, Tool>) {
+    map.insert(
+        "list_tasks",
+        Tool {
+            declaration: declaration(),
+            execute,
+        },
+    );
 }

--- a/src/tools/run_bash.rs
+++ b/src/tools/run_bash.rs
@@ -3,6 +3,8 @@ use serde_json::Value;
 use std::process::Command;
 
 use crate::agent::FunctionDeclaration;
+use crate::tools::Tool;
+use std::collections::HashMap;
 
 const DECL_JSON: &str = include_str!("../../tools/run_bash.json");
 
@@ -25,4 +27,14 @@ pub fn execute(args: &Value) -> Result<String> {
             String::from_utf8_lossy(&output.stderr)
         ))
     }
+}
+
+pub fn register(map: &mut HashMap<&'static str, Tool>) {
+    map.insert(
+        "run_bash",
+        Tool {
+            declaration: declaration(),
+            execute,
+        },
+    );
 }

--- a/src/tools/run_python.rs
+++ b/src/tools/run_python.rs
@@ -3,6 +3,8 @@ use serde_json::Value;
 use std::process::Command;
 
 use crate::agent::FunctionDeclaration;
+use crate::tools::Tool;
+use std::collections::HashMap;
 
 const DECL_JSON: &str = include_str!("../../tools/run_python.json");
 
@@ -25,4 +27,14 @@ pub fn execute(args: &Value) -> Result<String> {
             String::from_utf8_lossy(&output.stderr)
         ))
     }
+}
+
+pub fn register(map: &mut HashMap<&'static str, Tool>) {
+    map.insert(
+        "run_python",
+        Tool {
+            declaration: declaration(),
+            execute,
+        },
+    );
 }


### PR DESCRIPTION
## Summary
- manage built-in tools via a `HashMap` initialized once with `once_cell`
- add `Tool` struct to hold tool metadata
- register each tool module with the map
- update precommit dependencies

## Testing
- `./scripts/precommit.sh`

------
https://chatgpt.com/codex/tasks/task_e_687d90bc06c48320af5fd6d40a2f831a