### PR TITLE
Refactor CLI to use noun-first subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ This will create a `.taskter` directory to store all your tasks, agents, and pro
 Next, create an agent to help you with your tasks. For this example, we'll create a simple agent that can run bash commands:
 
 ```bash
-taskter add-agent --prompt "You are a helpful assistant that can run bash commands." --tools "run_bash" --model "gemini-2.5-pro"
+taskter agent add --prompt "You are a helpful assistant that can run bash commands." --tools "run_bash" --model "gemini-2.5-pro"
 ```
 
 You can list all available agents using:
 
 ```bash
-taskter show agents
+taskter agent list
 ```
 
 ### 3. Create a task
@@ -50,13 +50,13 @@ taskter show agents
 Now, let's create a task for your agent to complete:
 
 ```bash
-taskter add -t "List files in the current directory" -d "Use the ls -la command to list all files and folders in the current directory."
+taskter task add -t "List files in the current directory" -d "Use the ls -la command to list all files and folders in the current directory."
 ```
 
 You can see all your tasks by running:
 
 ```bash
-taskter list
+taskter task list
 ```
 
 ### 4. Assign the task to an agent
@@ -64,7 +64,7 @@ taskter list
 Assign the newly created task to your agent:
 
 ```bash
-taskter assign --task-id 1 --agent-id 1
+taskter task assign --task-id 1 --agent-id 1
 ```
 
 ### 5. Execute the task
@@ -72,7 +72,7 @@ taskter assign --task-id 1 --agent-id 1
 Finally, execute the task:
 
 ```bash
-taskter execute --task-id 1
+taskter task execute --task-id 1
 ```
 
 The agent will now run the task. If it's successful, the task will be marked as "Done". You can view the board at any time using the interactive UI:
@@ -197,7 +197,7 @@ In the interactive board, you can use the following keys:
 
 - **Add a new task:**
   ```bash
-  taskter add -t "My new task" -d "A description for my task"
+  taskter task add -t "My new task" -d "A description for my task"
   ```
 -  In the interactive board (`taskter board`), press `n` to add a task interactively. Enter the title, press `Enter`, then provide the description and press `Enter` again.
 
@@ -207,16 +207,16 @@ In the interactive board, you can use the following keys:
 
 - **List all tasks:**
   ```bash
-  taskter list
+  taskter task list
   ```
 
 - **Mark a task as done:**
   ```bash
-  taskter done <task_id>
+  taskter task complete --id <task_id>
   ```
 - **Add a comment to a task:**
   ```bash
-  taskter comment --task-id <task_id> --comment "Your note"
+  taskter task comment --task-id <task_id> --comment "Your note"
   ```
 
 ### Project information
@@ -256,7 +256,7 @@ Taskter now supports LLM-based agents that can be assigned to tasks. These agent
 
 - **Add a new agent:**
   ```bash
-  taskter add-agent --prompt "You are a helpful assistant." --tools "email" "calendar" --model "gemini-pro"
+  taskter agent add --prompt "You are a helpful assistant." --tools "email" "calendar" --model "gemini-pro"
   ```
   The `--tools` option accepts either paths to JSON files describing a tool or
   the name of a built-in tool. Built-ins live under the `tools/` directory of
@@ -266,16 +266,16 @@ Taskter now supports LLM-based agents that can be assigned to tasks. These agent
 
 - **Assign an agent to a task:**
   ```bash
-  taskter assign --task-id 1 --agent-id 1
+  taskter task assign --task-id 1 --agent-id 1
   ```
 
 - **Execute a task with an agent:**
   ```bash
-  taskter execute --task-id 1
+  taskter task execute --task-id 1
   ```
 - **List available agents:**
   ```bash
-  taskter show agents
+  taskter agent list
   ```
 - **List available tools:**
   ```bash
@@ -283,7 +283,7 @@ Taskter now supports LLM-based agents that can be assigned to tasks. These agent
   ```
 - **Delete an agent:**
   ```bash
-  taskter delete-agent --agent-id 1
+  taskter agent remove --id 1
   ```
 
 When a task is executed, the agent will attempt to perform the task. If successful, the task is marked as "Done". If it fails, the task is moved back to "To Do", unassigned, and a comment from the agent is added.
@@ -340,7 +340,7 @@ provided helper script:
 The script removes any existing `.taskter` directory, creates a new board with a
 few example tasks, sets a project description, defines OKRs and adds an agent
 using the built-in email tool. Once it finishes you can inspect the board with
-`taskter list` or launch the TUI via `taskter board`.
+`taskter task list` or launch the TUI via `taskter board`.
 
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -228,26 +228,26 @@ In the interactive board, you can use the following keys:
 
 - **Show project OKRs:**
   ```bash
-  taskter show okrs
+  taskter okrs list
   ```
 
 - **Show operation logs:**
   ```bash
-  taskter show logs
+  taskter logs list
   ```
 
 ### Manage OKRs
 
 - **Add a new OKR:**
   ```bash
-  taskter add-okr -o "My objective" -k "Key result 1" "Key result 2"
+  taskter okrs add -o "My objective" -k "Key result 1" "Key result 2"
   ```
 
 ### Manage logs
 
 - **Add a log entry:**
   ```bash
-  taskter log "This is a log message"
+  taskter logs add "This is a log message"
   ```
 
 ### Agents
@@ -279,7 +279,7 @@ Taskter now supports LLM-based agents that can be assigned to tasks. These agent
   ```
 - **List available tools:**
   ```bash
-  taskter show tools
+  taskter tools list
   ```
 - **Delete an agent:**
   ```bash

--- a/docs/src/agent_system.md
+++ b/docs/src/agent_system.md
@@ -4,10 +4,10 @@ Taskter supports LLM-based agents that can be assigned to tasks. These agents ca
 
 ## Creating an Agent
 
-You can create an agent using the `add-agent` subcommand. You need to provide a prompt, a list of tools, and a model.
+You can create an agent using the `agent add` subcommand. You need to provide a prompt, a list of tools, and a model.
 
 ```bash
-taskter add-agent --prompt "You are a helpful assistant." --tools "email" "calendar" --model "gemini-pro"
+taskter agent add --prompt "You are a helpful assistant." --tools "email" "calendar" --model "gemini-pro"
 ```
 
 The `--tools` option accepts either paths to JSON files describing a tool or the name of a built-in tool. Built-in tools are located in the `tools/` directory of the repository.
@@ -35,7 +35,7 @@ taskter show tools
 Once you have created an agent, you can assign it to a task using the `assign` subcommand:
 
 ```bash
-taskter assign --task-id 1 --agent-id 1
+taskter task assign --task-id 1 --agent-id 1
 ```
 
 ## Executing a Task
@@ -43,7 +43,7 @@ taskter assign --task-id 1 --agent-id 1
 To execute a task with an assigned agent, use the `execute` subcommand:
 
 ```bash
-taskter execute --task-id 1
+taskter task execute --task-id 1
 ```
 
 When a task is executed, the agent will attempt to perform the task. If successful, the task is marked as "Done". If it fails, the task is moved back to "To Do", unassigned, and a comment from the agent is added.

--- a/docs/src/agent_system.md
+++ b/docs/src/agent_system.md
@@ -27,7 +27,7 @@ Available built-in tools:
 You can display this list at any time with:
 
 ```bash
-taskter show tools
+taskter tools list
 ```
 
 ## Assigning an Agent to a Task

--- a/docs/src/cli_usage.md
+++ b/docs/src/cli_usage.md
@@ -21,13 +21,13 @@ This will create a `.taskter` directory to store all your tasks, agents, and pro
 Next, create an agent to help you with your tasks. For this example, we'll create a simple agent that can run bash commands:
 
 ```bash
-taskter add-agent --prompt "You are a helpful assistant that can run bash commands." --tools "run_bash" --model "gemini-pro"
+taskter agent add --prompt "You are a helpful assistant that can run bash commands." --tools "run_bash" --model "gemini-pro"
 ```
 
 You can list all available agents using:
 
 ```bash
-taskter show agents
+taskter agent list
 ```
 
 You can list the built-in tools with:
@@ -41,13 +41,13 @@ taskter show tools
 Now, let's create a task for your agent to complete:
 
 ```bash
-taskter add -t "List files in the current directory" -d "Use the ls -la command to list all files and folders in the current directory."
+taskter task add -t "List files in the current directory" -d "Use the ls -la command to list all files and folders in the current directory."
 ```
 
 You can see all your tasks by running:
 
 ```bash
-taskter list
+taskter task list
 ```
 
 ### 4. Assign the task to an agent
@@ -55,7 +55,7 @@ taskter list
 Assign the newly created task to your agent:
 
 ```bash
-taskter assign --task-id 1 --agent-id 1
+taskter task assign --task-id 1 --agent-id 1
 ```
 
 ### 5. Execute the task
@@ -63,7 +63,7 @@ taskter assign --task-id 1 --agent-id 1
 Finally, execute the task:
 
 ```bash
-taskter execute --task-id 1
+taskter task execute --task-id 1
 ```
 
 The agent will now run the task. If it's successful, the task will be marked as "Done". You can view the board at any time using the interactive UI:

--- a/docs/src/cli_usage.md
+++ b/docs/src/cli_usage.md
@@ -33,7 +33,7 @@ taskter agent list
 You can list the built-in tools with:
 
 ```bash
-taskter show tools
+taskter tools list
 ```
 
 ### 3. Create a task

--- a/scripts/setup_example_project.sh
+++ b/scripts/setup_example_project.sh
@@ -11,19 +11,19 @@ taskter init
 taskter description "Example project demonstrating Taskter features."
 
 # Add example tasks
-taskter add -t "Write documentation" -d "Describe how to use Taskter."
-taskter add -t "Plan v1 release" -d "Define scope and timeline."
-taskter add -t "Send status email" -d "Notify stakeholders about progress."
+taskter task add -t "Write documentation" -d "Describe how to use Taskter."
+taskter task add -t "Plan v1 release" -d "Define scope and timeline."
+taskter task add -t "Send status email" -d "Notify stakeholders about progress."
 
 # Define OKRs
-taskter add-okr -o "Deliver MVP" -k "Ship v1" "Collect user feedback"
+taskter okrs add -o "Deliver MVP" -k "Ship v1" "Collect user feedback"
 
 # Create an agent with the built-in email tool
-taskter add-agent --prompt "You are a helpful assistant." --tools email --model "gemini-pro"
+taskter agent add --prompt "You are a helpful assistant." --tools email --model "gemini-pro"
 
 # Assign agent to the email task
-taskter assign --task-id 3 --agent-id 1
+taskter task assign --task-id 3 --agent-id 1
 
 cat <<MSG
-Example board initialized. Run 'taskter list' or 'taskter board' to explore.
+Example board initialized. Run 'taskter task list' or 'taskter board' to explore.
 MSG

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,19 +26,20 @@ pub enum Commands {
         #[command(subcommand)]
         what: ShowCommands,
     },
-    /// Adds a new OKR
-    AddOkr {
-        /// The objective
-        #[arg(short, long)]
-        objective: String,
-        /// The key results
-        #[arg(short, long, num_args = 1..)]
-        key_results: Vec<String>,
+    /// Manage OKRs
+    Okrs {
+        #[command(subcommand)]
+        action: OkrCommands,
     },
-    /// Adds a log entry
-    Log {
-        /// The log message
-        message: String,
+    /// Manage logs
+    Logs {
+        #[command(subcommand)]
+        action: LogCommands,
+    },
+    /// Manage built-in tools
+    Tools {
+        #[command(subcommand)]
+        action: ToolCommands,
     },
     /// Opens the interactive board
     Board,
@@ -53,14 +54,38 @@ pub enum Commands {
 pub enum ShowCommands {
     /// Shows the project description
     Description,
-    /// Shows the project OKRs
-    Okrs,
-    /// Shows the operation logs
-    Logs,
-    /// Lists all agents
-    Agents,
-    /// Lists all built-in agent tools
-    Tools,
+}
+
+#[derive(Subcommand)]
+pub enum OkrCommands {
+    /// Adds a new OKR
+    Add {
+        /// The objective
+        #[arg(short, long)]
+        objective: String,
+        /// The key results
+        #[arg(short, long, num_args = 1..)]
+        key_results: Vec<String>,
+    },
+    /// Lists all OKRs
+    List,
+}
+
+#[derive(Subcommand)]
+pub enum LogCommands {
+    /// Adds a log entry
+    Add {
+        /// The log message
+        message: String,
+    },
+    /// Lists log entries
+    List,
+}
+
+#[derive(Subcommand)]
+pub enum ToolCommands {
+    /// Lists built-in tools
+    List,
 }
 
 #[derive(Subcommand)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,30 +11,15 @@ pub struct Cli {
 pub enum Commands {
     /// Initializes a new Taskter board
     Init,
-    /// Adds a new task
-    Add {
-        /// The title of the task
-        #[arg(short, long)]
-        title: String,
-        /// The description of the task
-        #[arg(short, long)]
-        description: Option<String>,
+    /// Task management commands
+    Task {
+        #[command(subcommand)]
+        action: TaskCommands,
     },
-    /// Lists all tasks
-    List,
-    /// Marks a task as done
-    Done {
-        /// The id of the task to mark as done
-        id: usize,
-    },
-    /// Adds a comment to a task
-    Comment {
-        /// The id of the task to comment on
-        #[arg(short, long)]
-        task_id: usize,
-        /// The comment text
-        #[arg(short, long)]
-        comment: String,
+    /// Agent management commands
+    Agent {
+        #[command(subcommand)]
+        action: AgentCommands,
     },
     /// Show project information
     Show {
@@ -62,9 +47,26 @@ pub enum Commands {
         /// The project description
         description: String,
     },
+}
+
+#[derive(Subcommand)]
+pub enum ShowCommands {
+    /// Shows the project description
+    Description,
+    /// Shows the project OKRs
+    Okrs,
+    /// Shows the operation logs
+    Logs,
+    /// Lists all agents
+    Agents,
+    /// Lists all built-in agent tools
+    Tools,
+}
+
+#[derive(Subcommand)]
+pub enum AgentCommands {
     /// Adds a new agent
-    #[command(name = "add-agent")]
-    AddAgent {
+    Add {
         /// The system prompt for the agent
         #[arg(short, long)]
         prompt: String,
@@ -74,6 +76,56 @@ pub enum Commands {
         /// The model to use for the agent
         #[arg(short, long)]
         model: String,
+    },
+    /// Lists all agents
+    List,
+    /// Removes an agent by id
+    Remove {
+        /// The id of the agent to delete
+        #[arg(long)]
+        id: usize,
+    },
+    /// Updates an agent's prompt and tools
+    Update {
+        /// The id of the agent to update
+        #[arg(long)]
+        id: usize,
+        /// The new system prompt for the agent
+        #[arg(short, long)]
+        prompt: String,
+        /// The new tools the agent can use
+        #[arg(short, long, num_args = 1..)]
+        tools: Vec<String>,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum TaskCommands {
+    /// Adds a new task
+    Add {
+        /// The title of the task
+        #[arg(short, long)]
+        title: String,
+        /// The description of the task
+        #[arg(short, long)]
+        description: Option<String>,
+    },
+    /// Lists all tasks
+    List,
+    /// Marks a task as complete
+    Complete {
+        /// The id of the task to mark as done
+        #[arg(long)]
+        id: usize,
+    },
+    /// Adds a comment to a task
+    Comment {
+        /// The id of the task to comment on
+        #[arg(short, long)]
+        task_id: usize,
+        /// The comment text
+        #[arg(short, long)]
+        comment: String,
     },
     /// Executes a task with an agent
     Execute {
@@ -90,38 +142,4 @@ pub enum Commands {
         #[arg(short, long)]
         agent_id: usize,
     },
-    /// Deletes an agent by id
-    #[command(name = "delete-agent")]
-    DeleteAgent {
-        /// The id of the agent to delete
-        #[arg(short, long)]
-        agent_id: usize,
-    },
-    /// Updates an agent's prompt and tools
-    #[command(name = "update-agent")]
-    UpdateAgent {
-        /// The id of the agent to update
-        #[arg(short = 'i', long)]
-        agent_id: usize,
-        /// The new system prompt for the agent
-        #[arg(short, long)]
-        prompt: String,
-        /// The new tools the agent can use
-        #[arg(short, long, num_args = 1..)]
-        tools: Vec<String>,
-    },
-}
-
-#[derive(Subcommand)]
-pub enum ShowCommands {
-    /// Shows the project description
-    Description,
-    /// Shows the project OKRs
-    Okrs,
-    /// Shows the operation logs
-    Logs,
-    /// Lists all agents
-    Agents,
-    /// Lists all built-in agent tools
-    Tools,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,54 +189,54 @@ async fn main() -> anyhow::Result<()> {
                 let description = fs::read_to_string(".taskter/description.md")?;
                 println!("{description}");
             }
-            ShowCommands::Okrs => {
+        },
+        Commands::Okrs { action } => match action {
+            OkrCommands::Add {
+                objective,
+                key_results,
+            } => {
+                let mut okrs = store::load_okrs()?;
+                let new_okr = store::Okr {
+                    objective: objective.clone(),
+                    key_results: key_results
+                        .iter()
+                        .map(|kr| store::KeyResult {
+                            name: kr.clone(),
+                            progress: 0.0,
+                        })
+                        .collect(),
+                };
+                okrs.push(new_okr);
+                store::save_okrs(&okrs)?;
+                println!("OKR added successfully.");
+            }
+            OkrCommands::List => {
                 let okrs = fs::read_to_string(".taskter/okrs.json")?;
                 println!("{okrs}");
             }
-            ShowCommands::Logs => {
+        },
+        Commands::Logs { action } => match action {
+            LogCommands::Add { message } => {
+                let mut file = fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(".taskter/logs.log")?;
+                let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S");
+                writeln!(file, "[{timestamp}] {message}")?;
+                println!("Log added successfully.");
+            }
+            LogCommands::List => {
                 let logs = fs::read_to_string(".taskter/logs.log")?;
                 println!("{logs}");
             }
-            ShowCommands::Agents => {
-                let agents = agent::list_agents()?;
-                for a in agents {
-                    println!("{}: {}", a.id, a.system_prompt);
-                }
-            }
-            ShowCommands::Tools => {
+        },
+        Commands::Tools { action } => match action {
+            ToolCommands::List => {
                 for t in tools::builtin_names() {
                     println!("{t}");
                 }
             }
         },
-        Commands::AddOkr {
-            objective,
-            key_results,
-        } => {
-            let mut okrs = store::load_okrs()?;
-            let new_okr = store::Okr {
-                objective: objective.clone(),
-                key_results: key_results
-                    .iter()
-                    .map(|kr| store::KeyResult {
-                        name: kr.clone(),
-                        progress: 0.0,
-                    })
-                    .collect(),
-            };
-            okrs.push(new_okr);
-            store::save_okrs(&okrs)?;
-            println!("OKR added successfully.");
-        }
-        Commands::Log { message } => {
-            let mut file = fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(".taskter/logs.log")?;
-            let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S");
-            writeln!(file, "[{timestamp}] {message}")?;
-            println!("Log added successfully.");
-        }
         Commands::Board => {
             tui::run_tui()?;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,52 +29,161 @@ async fn main() -> anyhow::Result<()> {
                 println!("Taskter board initialized.");
             }
         }
-        Commands::Add { title, description } => {
-            let mut board = store::load_board()?;
-            let new_task = store::Task {
-                id: board.tasks.len() + 1,
-                title: title.clone(),
-                description: description.clone(),
-                status: store::TaskStatus::ToDo,
-                agent_id: None,
-                comment: None,
-            };
-            board.tasks.push(new_task);
-            store::save_board(&board)?;
-            println!("Task added successfully.");
-        }
-        Commands::List => {
-            let board = store::load_board()?;
-            for task in board.tasks {
-                println!(
-                    "[{}] {} - {:?} - {:?}",
-                    task.id,
-                    task.title,
-                    task.status,
-                    task.description.unwrap_or_default()
-                );
-            }
-        }
-        Commands::Done { id } => {
-            let mut board = store::load_board()?;
-            if let Some(task) = board.tasks.iter_mut().find(|t| t.id == *id) {
-                task.status = store::TaskStatus::Done;
+        Commands::Task { action } => match action {
+            TaskCommands::Add { title, description } => {
+                let mut board = store::load_board()?;
+                let new_task = store::Task {
+                    id: board.tasks.len() + 1,
+                    title: title.clone(),
+                    description: description.clone(),
+                    status: store::TaskStatus::ToDo,
+                    agent_id: None,
+                    comment: None,
+                };
+                board.tasks.push(new_task);
                 store::save_board(&board)?;
-                println!("Task {id} marked as done.");
-            } else {
-                println!("Task with id {id} not found.");
+                println!("Task added successfully.");
             }
-        }
-        Commands::Comment { task_id, comment } => {
-            let mut board = store::load_board()?;
-            if let Some(task) = board.tasks.iter_mut().find(|t| t.id == *task_id) {
-                task.comment = Some(comment.clone());
+            TaskCommands::List => {
+                let board = store::load_board()?;
+                for task in board.tasks {
+                    println!(
+                        "[{}] {} - {:?} - {:?}",
+                        task.id,
+                        task.title,
+                        task.status,
+                        task.description.unwrap_or_default()
+                    );
+                }
+            }
+            TaskCommands::Complete { id } => {
+                let mut board = store::load_board()?;
+                if let Some(task) = board.tasks.iter_mut().find(|t| t.id == *id) {
+                    task.status = store::TaskStatus::Done;
+                    store::save_board(&board)?;
+                    println!("Task {id} marked as done.");
+                } else {
+                    println!("Task with id {id} not found.");
+                }
+            }
+            TaskCommands::Comment { task_id, comment } => {
+                let mut board = store::load_board()?;
+                if let Some(task) = board.tasks.iter_mut().find(|t| t.id == *task_id) {
+                    task.comment = Some(comment.clone());
+                    store::save_board(&board)?;
+                    println!("Comment added to task {task_id}.");
+                } else {
+                    println!("Task with id {task_id} not found.");
+                }
+            }
+            TaskCommands::Execute { task_id } => {
+                let mut board = store::load_board()?;
+                let agents = agent::load_agents()?;
+
+                if let Some(task) = board.tasks.iter_mut().find(|t| t.id == *task_id) {
+                    if let Some(agent_id) = task.agent_id {
+                        if let Some(agent) = agents.iter().find(|a| a.id == agent_id) {
+                            match agent::execute_task(agent, task).await {
+                                Ok(result) => match result {
+                                    agent::ExecutionResult::Success { comment } => {
+                                        task.status = store::TaskStatus::Done;
+                                        task.comment = Some(comment);
+                                        println!("Task {task_id} executed successfully.");
+                                    }
+                                    agent::ExecutionResult::Failure { comment } => {
+                                        task.status = store::TaskStatus::ToDo;
+                                        task.comment = Some(comment);
+                                        task.agent_id = None;
+                                        println!("Task {task_id} failed to execute.");
+                                    }
+                                },
+                                Err(e) => {
+                                    println!("Error executing task {task_id}: {e}");
+                                }
+                            }
+                        } else {
+                            println!("Agent with id {agent_id} not found.");
+                        }
+                    } else {
+                        println!("Task {task_id} is not assigned to an agent.");
+                    }
+                } else {
+                    println!("Task with id {task_id} not found.");
+                }
+
                 store::save_board(&board)?;
-                println!("Comment added to task {task_id}.");
-            } else {
-                println!("Task with id {task_id} not found.");
             }
-        }
+            TaskCommands::Assign { task_id, agent_id } => {
+                let mut board = store::load_board()?;
+                if let Some(task) = board.tasks.iter_mut().find(|t| t.id == *task_id) {
+                    task.agent_id = Some(*agent_id);
+                    store::save_board(&board)?;
+                    println!("Agent {agent_id} assigned to task {task_id}.");
+                } else {
+                    println!("Task with id {task_id} not found.");
+                }
+            }
+        },
+        Commands::Agent { action } => match action {
+            AgentCommands::Add {
+                prompt,
+                tools,
+                model,
+            } => {
+                let mut agents = agent::load_agents()?;
+                let mut function_declarations = Vec::new();
+                for spec in tools {
+                    let decl = if Path::new(spec).exists() {
+                        let tool_content = fs::read_to_string(spec)?;
+                        let tool_json: serde_json::Value = serde_json::from_str(&tool_content)?;
+                        serde_json::from_value(tool_json)?
+                    } else if let Some(built) = tools::builtin_declaration(spec) {
+                        built
+                    } else {
+                        return Err(anyhow::anyhow!(format!("Unknown tool: {spec}")));
+                    };
+                    function_declarations.push(decl);
+                }
+
+                let new_agent = agent::Agent {
+                    id: agents.len() + 1,
+                    system_prompt: prompt.clone(),
+                    tools: function_declarations,
+                    model: model.clone(),
+                };
+                agents.push(new_agent);
+                agent::save_agents(&agents)?;
+                println!("Agent added successfully.");
+            }
+            AgentCommands::List => {
+                let agents = agent::list_agents()?;
+                for a in agents {
+                    println!("{}: {}", a.id, a.system_prompt);
+                }
+            }
+            AgentCommands::Remove { id } => {
+                agent::delete_agent(*id)?;
+                println!("Agent {id} deleted.");
+            }
+            AgentCommands::Update { id, prompt, tools } => {
+                let mut function_declarations = Vec::new();
+                for spec in tools {
+                    let decl = if Path::new(spec).exists() {
+                        let tool_content = fs::read_to_string(spec)?;
+                        let tool_json: serde_json::Value = serde_json::from_str(&tool_content)?;
+                        serde_json::from_value(tool_json)?
+                    } else if let Some(built) = tools::builtin_declaration(spec) {
+                        built
+                    } else {
+                        return Err(anyhow::anyhow!(format!("Unknown tool: {spec}")));
+                    };
+                    function_declarations.push(decl);
+                }
+
+                agent::update_agent(*id, prompt.clone(), function_declarations)?;
+                println!("Agent {id} updated.");
+            }
+        },
         Commands::Show { what } => match what {
             ShowCommands::Description => {
                 let description = fs::read_to_string(".taskter/description.md")?;
@@ -134,109 +243,6 @@ async fn main() -> anyhow::Result<()> {
         Commands::Description { description } => {
             fs::write(".taskter/description.md", description)?;
             println!("Project description updated successfully.");
-        }
-        Commands::AddAgent {
-            prompt,
-            tools,
-            model,
-        } => {
-            let mut agents = agent::load_agents()?;
-            let mut function_declarations = Vec::new();
-            for spec in tools {
-                let decl = if Path::new(spec).exists() {
-                    let tool_content = fs::read_to_string(spec)?;
-                    let tool_json: serde_json::Value = serde_json::from_str(&tool_content)?;
-                    serde_json::from_value(tool_json)?
-                } else if let Some(built) = tools::builtin_declaration(spec) {
-                    built
-                } else {
-                    return Err(anyhow::anyhow!(format!("Unknown tool: {spec}")));
-                };
-                function_declarations.push(decl);
-            }
-
-            let new_agent = agent::Agent {
-                id: agents.len() + 1,
-                system_prompt: prompt.clone(),
-                tools: function_declarations,
-                model: model.clone(),
-            };
-            agents.push(new_agent);
-            agent::save_agents(&agents)?;
-            println!("Agent added successfully.");
-        }
-        Commands::Execute { task_id } => {
-            let mut board = store::load_board()?;
-            let agents = agent::load_agents()?;
-
-            if let Some(task) = board.tasks.iter_mut().find(|t| t.id == *task_id) {
-                if let Some(agent_id) = task.agent_id {
-                    if let Some(agent) = agents.iter().find(|a| a.id == agent_id) {
-                        match agent::execute_task(agent, task).await {
-                            Ok(result) => match result {
-                                agent::ExecutionResult::Success { comment } => {
-                                    task.status = store::TaskStatus::Done;
-                                    task.comment = Some(comment);
-                                    println!("Task {task_id} executed successfully.");
-                                }
-                                agent::ExecutionResult::Failure { comment } => {
-                                    task.status = store::TaskStatus::ToDo;
-                                    task.comment = Some(comment);
-                                    task.agent_id = None;
-                                    println!("Task {task_id} failed to execute.");
-                                }
-                            },
-                            Err(e) => {
-                                println!("Error executing task {task_id}: {e}");
-                            }
-                        }
-                    } else {
-                        println!("Agent with id {agent_id} not found.");
-                    }
-                } else {
-                    println!("Task {task_id} is not assigned to an agent.");
-                }
-            } else {
-                println!("Task with id {task_id} not found.");
-            }
-
-            store::save_board(&board)?;
-        }
-        Commands::Assign { task_id, agent_id } => {
-            let mut board = store::load_board()?;
-            if let Some(task) = board.tasks.iter_mut().find(|t| t.id == *task_id) {
-                task.agent_id = Some(*agent_id);
-                store::save_board(&board)?;
-                println!("Agent {agent_id} assigned to task {task_id}.");
-            } else {
-                println!("Task with id {task_id} not found.");
-            }
-        }
-        Commands::UpdateAgent {
-            agent_id,
-            prompt,
-            tools,
-        } => {
-            let mut function_declarations = Vec::new();
-            for spec in tools {
-                let decl = if Path::new(spec).exists() {
-                    let tool_content = fs::read_to_string(spec)?;
-                    let tool_json: serde_json::Value = serde_json::from_str(&tool_content)?;
-                    serde_json::from_value(tool_json)?
-                } else if let Some(built) = tools::builtin_declaration(spec) {
-                    built
-                } else {
-                    return Err(anyhow::anyhow!(format!("Unknown tool: {spec}")));
-                };
-                function_declarations.push(decl);
-            }
-
-            agent::update_agent(*agent_id, prompt.clone(), function_declarations)?;
-            println!("Agent {agent_id} updated.");
-        }
-        Commands::DeleteAgent { agent_id } => {
-            agent::delete_agent(*agent_id)?;
-            println!("Agent {agent_id} deleted.");
         }
     }
 

--- a/tests/cli_commands.rs
+++ b/tests/cli_commands.rs
@@ -19,7 +19,7 @@ fn add_list_done_workflow() {
         // Add a task
         Command::cargo_bin("taskter")
             .unwrap()
-            .args(["add", "--title", "Test task"])
+            .args(["task", "add", "--title", "Test task"])
             .assert()
             .success()
             .stdout(predicate::str::contains("Task added successfully"));
@@ -27,7 +27,7 @@ fn add_list_done_workflow() {
         // Verify list output contains the task
         let out = Command::cargo_bin("taskter")
             .unwrap()
-            .arg("list")
+            .args(["task", "list"])
             .assert()
             .success()
             .get_output()
@@ -39,7 +39,7 @@ fn add_list_done_workflow() {
         // Mark the task as done
         Command::cargo_bin("taskter")
             .unwrap()
-            .args(["done", "1"])
+            .args(["task", "complete", "--id", "1"])
             .assert()
             .success()
             .stdout(predicate::str::contains("marked as done"));
@@ -64,7 +64,7 @@ fn add_agent_and_execute_task() {
         // add a task
         Command::cargo_bin("taskter")
             .unwrap()
-            .args(["add", "--title", "Send email"])
+            .args(["task", "add", "--title", "Send email"])
             .assert()
             .success();
 
@@ -72,7 +72,8 @@ fn add_agent_and_execute_task() {
         Command::cargo_bin("taskter")
             .unwrap()
             .args([
-                "add-agent",
+                "agent",
+                "add",
                 "--prompt",
                 "email agent",
                 "--tools",
@@ -86,14 +87,14 @@ fn add_agent_and_execute_task() {
         // assign agent to task
         Command::cargo_bin("taskter")
             .unwrap()
-            .args(["assign", "--task-id", "1", "--agent-id", "1"])
+            .args(["task", "assign", "--task-id", "1", "--agent-id", "1"])
             .assert()
             .success();
 
         // execute the task
         Command::cargo_bin("taskter")
             .unwrap()
-            .args(["execute", "--task-id", "1"])
+            .args(["task", "execute", "--task-id", "1"])
             .assert()
             .success();
 
@@ -115,13 +116,7 @@ fn list_and_delete_agents() {
         Command::cargo_bin("taskter")
             .unwrap()
             .args([
-                "add-agent",
-                "--prompt",
-                "helper",
-                "--tools",
-                "email",
-                "--model",
-                "gpt-4o",
+                "agent", "add", "--prompt", "helper", "--tools", "email", "--model", "gpt-4o",
             ])
             .assert()
             .success();
@@ -129,7 +124,7 @@ fn list_and_delete_agents() {
         // list agents
         let out = Command::cargo_bin("taskter")
             .unwrap()
-            .args(["show", "agents"])
+            .args(["agent", "list"])
             .assert()
             .success()
             .get_output()
@@ -141,7 +136,7 @@ fn list_and_delete_agents() {
         // delete agent
         Command::cargo_bin("taskter")
             .unwrap()
-            .args(["delete-agent", "--agent-id", "1"])
+            .args(["agent", "remove", "--id", "1"])
             .assert()
             .success()
             .stdout(predicate::str::contains("Agent 1 deleted."));
@@ -165,13 +160,7 @@ fn update_agent_changes_configuration() {
         Command::cargo_bin("taskter")
             .unwrap()
             .args([
-                "add-agent",
-                "--prompt",
-                "helper",
-                "--tools",
-                "email",
-                "--model",
-                "gpt-4o",
+                "agent", "add", "--prompt", "helper", "--tools", "email", "--model", "gpt-4o",
             ])
             .assert()
             .success();
@@ -180,8 +169,9 @@ fn update_agent_changes_configuration() {
         Command::cargo_bin("taskter")
             .unwrap()
             .args([
-                "update-agent",
-                "--agent-id",
+                "agent",
+                "update",
+                "--id",
                 "1",
                 "--prompt",
                 "new helper",

--- a/tests/cli_commands.rs
+++ b/tests/cli_commands.rs
@@ -201,7 +201,7 @@ fn add_okr_log_and_description() {
         // add okr
         Command::cargo_bin("taskter")
             .unwrap()
-            .args(["add-okr", "-o", "Improve UI", "-k", "Faster", "Better"])
+            .args(["okrs", "add", "-o", "Improve UI", "-k", "Faster", "Better"])
             .assert()
             .success()
             .stdout(predicate::str::contains("OKR added successfully"));
@@ -214,7 +214,7 @@ fn add_okr_log_and_description() {
         // add log entry
         Command::cargo_bin("taskter")
             .unwrap()
-            .args(["log", "Initial commit"])
+            .args(["logs", "add", "Initial commit"])
             .assert()
             .success()
             .stdout(predicate::str::contains("Log added successfully"));
@@ -248,7 +248,7 @@ fn show_tools_lists_builtins() {
 
         let out = Command::cargo_bin("taskter")
             .unwrap()
-            .args(["show", "tools"])
+            .args(["tools", "list"])
             .assert()
             .success()
             .get_output()


### PR DESCRIPTION
## Summary
- restructure CLI parsing to support hierarchical `agent` and `task` commands
- update main command handler
- refresh tests for new syntax
- revise README and docs with noun-first examples

## Testing
- `./scripts/precommit.sh`

------
https://chatgpt.com/codex/tasks/task_e_687e32ab78888320b479d6ea8bd8f5e9