### PR TITLE
Introduce config constants for .taskter paths

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -8,7 +8,8 @@ use serde_json::{json, Value};
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
-use std::path::Path;
+
+use crate::config;
 
 #[derive(Debug, PartialEq)]
 pub enum ExecutionResult {
@@ -20,7 +21,7 @@ fn append_log(message: &str) -> anyhow::Result<()> {
     let mut file = OpenOptions::new()
         .create(true)
         .append(true)
-        .open(".taskter/logs.log")?;
+        .open(config::log_path())?;
     let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S");
     writeln!(file, "[{timestamp}] {message}")?;
     Ok(())
@@ -261,7 +262,7 @@ pub struct Agent {
 }
 
 pub fn load_agents() -> anyhow::Result<Vec<Agent>> {
-    let path = Path::new(".taskter/agents.json");
+    let path = config::agents_path();
     if !path.exists() {
         fs::create_dir_all(path.parent().unwrap())?;
         fs::write(path, "[]")?;
@@ -273,7 +274,7 @@ pub fn load_agents() -> anyhow::Result<Vec<Agent>> {
 }
 
 pub fn save_agents(agents: &[Agent]) -> anyhow::Result<()> {
-    let path = Path::new(".taskter/agents.json");
+    let path = config::agents_path();
     let content = serde_json::to_string_pretty(agents)?;
     fs::write(path, content)?;
     Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,39 @@
+/// Constants for paths inside the `.taskter` directory.
+use std::path::Path;
+
+pub const DIR: &str = ".taskter";
+
+pub const BOARD_FILE: &str = ".taskter/board.json";
+pub const OKRS_FILE: &str = ".taskter/okrs.json";
+pub const LOG_FILE: &str = ".taskter/logs.log";
+pub const AGENTS_FILE: &str = ".taskter/agents.json";
+pub const DESCRIPTION_FILE: &str = ".taskter/description.md";
+pub const EMAIL_CONFIG_FILE: &str = ".taskter/email_config.json";
+
+pub fn dir() -> &'static Path {
+    Path::new(DIR)
+}
+
+pub fn board_path() -> &'static Path {
+    Path::new(BOARD_FILE)
+}
+
+pub fn okrs_path() -> &'static Path {
+    Path::new(OKRS_FILE)
+}
+
+pub fn log_path() -> &'static Path {
+    Path::new(LOG_FILE)
+}
+
+pub fn agents_path() -> &'static Path {
+    Path::new(AGENTS_FILE)
+}
+
+pub fn description_path() -> &'static Path {
+    Path::new(DESCRIPTION_FILE)
+}
+
+pub fn email_config_path() -> &'static Path {
+    Path::new(EMAIL_CONFIG_FILE)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod agent;
 pub mod cli;
+pub mod config;
 pub mod store;
 pub mod tools;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@ use std::fs;
 use std::io::Write;
 use std::path::Path;
 
+use taskter::config;
+
 use taskter::cli::*;
 mod agent;
 mod store;
@@ -16,7 +18,7 @@ async fn main() -> anyhow::Result<()> {
 
     match &cli.command {
         Commands::Init => {
-            let path = Path::new(".taskter");
+            let path = config::dir();
             if path.exists() {
                 println!("Taskter board already initialized.");
             } else {
@@ -186,7 +188,7 @@ async fn main() -> anyhow::Result<()> {
         },
         Commands::Show { what } => match what {
             ShowCommands::Description => {
-                let description = fs::read_to_string(".taskter/description.md")?;
+                let description = fs::read_to_string(config::description_path())?;
                 println!("{description}");
             }
         },
@@ -211,7 +213,7 @@ async fn main() -> anyhow::Result<()> {
                 println!("OKR added successfully.");
             }
             OkrCommands::List => {
-                let okrs = fs::read_to_string(".taskter/okrs.json")?;
+                let okrs = fs::read_to_string(config::okrs_path())?;
                 println!("{okrs}");
             }
         },
@@ -220,13 +222,13 @@ async fn main() -> anyhow::Result<()> {
                 let mut file = fs::OpenOptions::new()
                     .create(true)
                     .append(true)
-                    .open(".taskter/logs.log")?;
+                    .open(config::log_path())?;
                 let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S");
                 writeln!(file, "[{timestamp}] {message}")?;
                 println!("Log added successfully.");
             }
             LogCommands::List => {
-                let logs = fs::read_to_string(".taskter/logs.log")?;
+                let logs = fs::read_to_string(config::log_path())?;
                 println!("{logs}");
             }
         },
@@ -241,7 +243,7 @@ async fn main() -> anyhow::Result<()> {
             tui::run_tui()?;
         }
         Commands::Description { description } => {
-            fs::write(".taskter/description.md", description)?;
+            fs::write(config::description_path(), description)?;
             println!("Project description updated successfully.");
         }
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::Path;
+
+use crate::config;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum TaskStatus {
@@ -37,7 +38,7 @@ pub struct Okr {
 }
 
 pub fn load_board() -> anyhow::Result<Board> {
-    let path = Path::new(".taskter/board.json");
+    let path = config::board_path();
     if !path.exists() {
         return Ok(Board::default());
     }
@@ -48,14 +49,14 @@ pub fn load_board() -> anyhow::Result<Board> {
 }
 
 pub fn save_board(board: &Board) -> anyhow::Result<()> {
-    let path = Path::new(".taskter/board.json");
+    let path = config::board_path();
     let content = serde_json::to_string_pretty(board)?;
     fs::write(path, content)?;
     Ok(())
 }
 
 pub fn load_okrs() -> anyhow::Result<Vec<Okr>> {
-    let path = Path::new(".taskter/okrs.json");
+    let path = config::okrs_path();
     if !path.exists() {
         return Ok(Vec::new());
     }
@@ -66,7 +67,7 @@ pub fn load_okrs() -> anyhow::Result<Vec<Okr>> {
 }
 
 pub fn save_okrs(okrs: &[Okr]) -> anyhow::Result<()> {
-    let path = Path::new(".taskter/okrs.json");
+    let path = config::okrs_path();
     let content = serde_json::to_string_pretty(okrs)?;
     fs::write(path, content)?;
     Ok(())

--- a/src/tools/add_log.rs
+++ b/src/tools/add_log.rs
@@ -5,6 +5,7 @@ use std::fs::OpenOptions;
 use std::io::Write;
 
 use crate::agent::FunctionDeclaration;
+use crate::config;
 use crate::tools::Tool;
 use std::collections::HashMap;
 
@@ -21,7 +22,7 @@ pub fn execute(args: &Value) -> Result<String> {
     let mut file = OpenOptions::new()
         .create(true)
         .append(true)
-        .open(".taskter/logs.log")?;
+        .open(config::log_path())?;
     let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S");
     writeln!(file, "[{timestamp}] {message}")?;
     Ok("Log entry added".to_string())

--- a/src/tools/email.rs
+++ b/src/tools/email.rs
@@ -3,9 +3,9 @@ use lettre::{transport::smtp::authentication::Credentials, Message, SmtpTranspor
 use serde::Deserialize;
 use serde_json::Value;
 use std::fs;
-use std::path::Path;
 
 use crate::agent::FunctionDeclaration;
+use crate::config;
 use crate::tools::Tool;
 use std::collections::HashMap;
 
@@ -36,7 +36,7 @@ pub fn execute(args: &Value) -> Result<String> {
 }
 
 fn send_email(to: &str, subject: &str, body: &str) -> Result<()> {
-    let config_path = Path::new(".taskter/email_config.json");
+    let config_path = config::email_config_path();
     let config_str = match fs::read_to_string(config_path) {
         Ok(content) => content,
         Err(_) => return Err(anyhow::anyhow!("Email configuration not found")),

--- a/src/tools/get_description.rs
+++ b/src/tools/get_description.rs
@@ -3,6 +3,7 @@ use serde_json::Value;
 use std::fs;
 
 use crate::agent::FunctionDeclaration;
+use crate::config;
 use crate::tools::Tool;
 use std::collections::HashMap;
 
@@ -13,7 +14,7 @@ pub fn declaration() -> FunctionDeclaration {
 }
 
 pub fn execute(_args: &Value) -> Result<String> {
-    let content = fs::read_to_string(".taskter/description.md")?;
+    let content = fs::read_to_string(config::description_path())?;
     Ok(content)
 }
 

--- a/tests/cli_commands.rs
+++ b/tests/cli_commands.rs
@@ -46,7 +46,8 @@ fn add_list_done_workflow() {
 
         // Inspect board file
         let board: Value =
-            serde_json::from_str(&fs::read_to_string(".taskter/board.json").unwrap()).unwrap();
+            serde_json::from_str(&fs::read_to_string(taskter::config::BOARD_FILE).unwrap())
+                .unwrap();
         assert_eq!(board["tasks"][0]["status"], "Done");
     });
 }
@@ -99,7 +100,8 @@ fn add_agent_and_execute_task() {
             .success();
 
         let board: Value =
-            serde_json::from_str(&fs::read_to_string(".taskter/board.json").unwrap()).unwrap();
+            serde_json::from_str(&fs::read_to_string(taskter::config::BOARD_FILE).unwrap())
+                .unwrap();
         assert_eq!(board["tasks"][0]["status"], "Done");
     });
 }
@@ -142,7 +144,8 @@ fn list_and_delete_agents() {
             .stdout(predicate::str::contains("Agent 1 deleted."));
 
         let agents: Vec<Value> =
-            serde_json::from_str(&fs::read_to_string(".taskter/agents.json").unwrap()).unwrap();
+            serde_json::from_str(&fs::read_to_string(taskter::config::AGENTS_FILE).unwrap())
+                .unwrap();
         assert!(agents.is_empty());
     });
 }
@@ -183,7 +186,8 @@ fn update_agent_changes_configuration() {
             .stdout(predicate::str::contains("Agent 1 updated."));
 
         let agents: Vec<Value> =
-            serde_json::from_str(&fs::read_to_string(".taskter/agents.json").unwrap()).unwrap();
+            serde_json::from_str(&fs::read_to_string(taskter::config::AGENTS_FILE).unwrap())
+                .unwrap();
         assert_eq!(agents[0]["system_prompt"], "new helper");
         assert_eq!(agents[0]["tools"][0]["name"], "create_task");
     });
@@ -207,7 +211,7 @@ fn add_okr_log_and_description() {
             .stdout(predicate::str::contains("OKR added successfully"));
 
         let okrs: Value =
-            serde_json::from_str(&fs::read_to_string(".taskter/okrs.json").unwrap()).unwrap();
+            serde_json::from_str(&fs::read_to_string(taskter::config::OKRS_FILE).unwrap()).unwrap();
         assert_eq!(okrs.as_array().unwrap().len(), 1);
         assert_eq!(okrs[0]["objective"], "Improve UI");
 
@@ -219,7 +223,7 @@ fn add_okr_log_and_description() {
             .success()
             .stdout(predicate::str::contains("Log added successfully"));
 
-        let logs = fs::read_to_string(".taskter/logs.log").unwrap();
+        let logs = fs::read_to_string(taskter::config::LOG_FILE).unwrap();
         assert!(logs.contains("Initial commit"));
 
         // update description
@@ -232,7 +236,7 @@ fn add_okr_log_and_description() {
                 "Project description updated successfully",
             ));
 
-        let desc = fs::read_to_string(".taskter/description.md").unwrap();
+        let desc = fs::read_to_string(taskter::config::DESCRIPTION_FILE).unwrap();
         assert_eq!(desc, "A great project");
     });
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -3,7 +3,7 @@ pub fn with_temp_dir<F: FnOnce() -> T, T>(test: F) -> T {
     let original_dir = std::env::current_dir().expect("cannot read current dir");
     std::env::set_current_dir(tmp.path()).expect("cannot set current dir");
 
-    std::fs::create_dir(".taskter").unwrap();
+    std::fs::create_dir(taskter::config::DIR).unwrap();
 
     let result = test();
 

--- a/tests/tool_functions.rs
+++ b/tests/tool_functions.rs
@@ -128,7 +128,7 @@ fn add_okr_requires_fields() {
 fn add_log_appends_message() {
     with_temp_dir(|| {
         add_log::execute(&json!({"message":"hello"})).unwrap();
-        let content = fs::read_to_string(".taskter/logs.log").unwrap();
+        let content = fs::read_to_string(taskter::config::LOG_FILE).unwrap();
         assert!(content.contains("hello"));
     });
 }
@@ -197,7 +197,7 @@ fn list_tasks_empty_when_none() {
 #[test]
 fn get_description_reads_file() {
     with_temp_dir(|| {
-        fs::write(".taskter/description.md", "desc").unwrap();
+        fs::write(taskter::config::DESCRIPTION_FILE, "desc").unwrap();
         let out = get_description::execute(&json!({})).unwrap();
         assert_eq!(out, "desc");
     });


### PR DESCRIPTION
## Summary
- centralize `.taskter` paths in new `config` module
- update core modules and tools to use these constants
- adjust tests to reference new constants

## Testing
- `cargo fmt`
- `cargo clippy --all-targets --all-features`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687e413f715c83208240d90b862f4dce