### PR TITLE
Improve docs for public API

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -10,6 +10,7 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
 
+/// Result of running an [`Agent`] on a [`Task`].
 #[derive(Debug, PartialEq)]
 pub enum ExecutionResult {
     Success { comment: String },
@@ -26,6 +27,9 @@ fn append_log(message: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Executes a task with the given agent and records progress in `.taskter/logs.log`.
+///
+/// Tools referenced by the agent may be invoked during execution.
 pub async fn execute_task(agent: &Agent, task: &Task) -> Result<ExecutionResult> {
     let client = Client::new();
     if let Err(e) = append_log(&format!(
@@ -240,6 +244,7 @@ pub async fn execute_task(agent: &Agent, task: &Task) -> Result<ExecutionResult>
     }
 }
 
+/// Describes an available tool for the language model.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct FunctionDeclaration {
     pub name: String,
@@ -252,6 +257,7 @@ fn empty_params() -> Value {
     serde_json::json!({})
 }
 
+/// Configuration for an autonomous agent stored in `.taskter/agents.json`.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Agent {
     pub id: usize,
@@ -260,6 +266,9 @@ pub struct Agent {
     pub model: String,
 }
 
+/// Loads the list of agents from `.taskter/agents.json`.
+///
+/// The file is created if it does not exist.
 pub fn load_agents() -> anyhow::Result<Vec<Agent>> {
     let path = Path::new(".taskter/agents.json");
     if !path.exists() {
@@ -272,6 +281,7 @@ pub fn load_agents() -> anyhow::Result<Vec<Agent>> {
     Ok(agents)
 }
 
+/// Writes the provided agents to `.taskter/agents.json`.
 pub fn save_agents(agents: &[Agent]) -> anyhow::Result<()> {
     let path = Path::new(".taskter/agents.json");
     let content = serde_json::to_string_pretty(agents)?;
@@ -279,10 +289,12 @@ pub fn save_agents(agents: &[Agent]) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Convenience wrapper around [`load_agents`].
 pub fn list_agents() -> anyhow::Result<Vec<Agent>> {
     load_agents()
 }
 
+/// Removes an agent from `.taskter/agents.json` by ID.
 pub fn delete_agent(id: usize) -> anyhow::Result<()> {
     let mut agents = load_agents()?;
     if let Some(pos) = agents.iter().position(|a| a.id == id) {
@@ -292,6 +304,7 @@ pub fn delete_agent(id: usize) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Updates an existing agent in `.taskter/agents.json`.
 pub fn update_agent(
     id: usize,
     prompt: String,

--- a/src/store.rs
+++ b/src/store.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
 
+/// Progress state of a [`Task`].
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum TaskStatus {
     ToDo,
@@ -9,6 +10,7 @@ pub enum TaskStatus {
     Done,
 }
 
+/// A single task stored in `.taskter/board.json`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Task {
     pub id: usize,
@@ -19,23 +21,29 @@ pub struct Task {
     pub comment: Option<String>,
 }
 
+/// Collection of tasks comprising the Kanban board.
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq)]
 pub struct Board {
     pub tasks: Vec<Task>,
 }
 
+/// A measurable key result belonging to an [`Okr`].
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct KeyResult {
     pub name: String,
     pub progress: f32,
 }
 
+/// Objective with its associated key results stored in `.taskter/okrs.json`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Okr {
     pub objective: String,
     pub key_results: Vec<KeyResult>,
 }
 
+/// Reads the Kanban board from `.taskter/board.json`.
+///
+/// Returns an empty board if the file does not exist.
 pub fn load_board() -> anyhow::Result<Board> {
     let path = Path::new(".taskter/board.json");
     if !path.exists() {
@@ -47,6 +55,7 @@ pub fn load_board() -> anyhow::Result<Board> {
     Ok(board)
 }
 
+/// Writes the current board state to `.taskter/board.json`.
 pub fn save_board(board: &Board) -> anyhow::Result<()> {
     let path = Path::new(".taskter/board.json");
     let content = serde_json::to_string_pretty(board)?;
@@ -54,6 +63,9 @@ pub fn save_board(board: &Board) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Loads all OKRs from `.taskter/okrs.json`.
+///
+/// Returns an empty list if the file is missing.
 pub fn load_okrs() -> anyhow::Result<Vec<Okr>> {
     let path = Path::new(".taskter/okrs.json");
     if !path.exists() {
@@ -65,6 +77,7 @@ pub fn load_okrs() -> anyhow::Result<Vec<Okr>> {
     Ok(okrs)
 }
 
+/// Persists OKRs to `.taskter/okrs.json`.
 pub fn save_okrs(okrs: &[Okr]) -> anyhow::Result<()> {
     let path = Path::new(".taskter/okrs.json");
     let content = serde_json::to_string_pretty(okrs)?;

--- a/src/tools/add_log.rs
+++ b/src/tools/add_log.rs
@@ -10,10 +10,12 @@ use std::collections::HashMap;
 
 const DECL_JSON: &str = include_str!("../../tools/add_log.json");
 
+/// Returns the function declaration for this tool.
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid add_log.json")
 }
 
+/// Appends a log entry to `.taskter/logs.log`.
 pub fn execute(args: &Value) -> Result<String> {
     let message = args["message"]
         .as_str()
@@ -27,6 +29,7 @@ pub fn execute(args: &Value) -> Result<String> {
     Ok("Log entry added".to_string())
 }
 
+/// Registers the tool in the provided map.
 pub fn register(map: &mut HashMap<&'static str, Tool>) {
     map.insert(
         "add_log",

--- a/src/tools/add_okr.rs
+++ b/src/tools/add_okr.rs
@@ -8,10 +8,12 @@ use std::collections::HashMap;
 
 const DECL_JSON: &str = include_str!("../../tools/add_okr.json");
 
+/// Returns the function declaration for this tool.
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid add_okr.json")
 }
 
+/// Adds a new OKR to `.taskter/okrs.json`.
 pub fn execute(args: &Value) -> Result<String> {
     let objective = args["objective"]
         .as_str()
@@ -39,6 +41,7 @@ pub fn execute(args: &Value) -> Result<String> {
     Ok(format!("Added OKR '{objective}'"))
 }
 
+/// Registers the tool in the provided map.
 pub fn register(map: &mut HashMap<&'static str, Tool>) {
     map.insert(
         "add_okr",

--- a/src/tools/assign_agent.rs
+++ b/src/tools/assign_agent.rs
@@ -8,10 +8,12 @@ use std::collections::HashMap;
 
 const DECL_JSON: &str = include_str!("../../tools/assign_agent.json");
 
+/// Returns the function declaration for this tool.
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid assign_agent.json")
 }
 
+/// Assigns an agent to a task in `.taskter/board.json`.
 pub fn execute(args: &Value) -> Result<String> {
     let task_id = args["task_id"]
         .as_u64()
@@ -35,6 +37,7 @@ pub fn execute(args: &Value) -> Result<String> {
     }
 }
 
+/// Registers the tool in the provided map.
 pub fn register(map: &mut HashMap<&'static str, Tool>) {
     map.insert(
         "assign_agent",

--- a/src/tools/create_task.rs
+++ b/src/tools/create_task.rs
@@ -8,10 +8,12 @@ use std::collections::HashMap;
 
 const DECL_JSON: &str = include_str!("../../tools/create_task.json");
 
+/// Returns the function declaration for this tool.
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid create_task.json")
 }
 
+/// Creates a new task in `.taskter/board.json`.
 pub fn execute(args: &Value) -> Result<String> {
     let title = args["title"]
         .as_str()
@@ -36,6 +38,7 @@ pub fn execute(args: &Value) -> Result<String> {
     Ok(format!("Created task {id}"))
 }
 
+/// Registers the tool in the provided map.
 pub fn register(map: &mut HashMap<&'static str, Tool>) {
     map.insert(
         "create_task",

--- a/src/tools/email.rs
+++ b/src/tools/email.rs
@@ -19,10 +19,12 @@ struct EmailConfig {
 
 const DECL_JSON: &str = include_str!("../../tools/send_email.json");
 
+/// Returns the function declaration for this tool.
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid send_email.json")
 }
 
+/// Sends an email using `.taskter/email_config.json` for credentials.
 pub fn execute(args: &Value) -> Result<String> {
     let to = args["to"].as_str().unwrap_or_default();
     let subject = args["subject"].as_str().unwrap_or_default();
@@ -60,6 +62,7 @@ fn send_email(to: &str, subject: &str, body: &str) -> Result<()> {
     mailer.send(&email).map(|_| ()).map_err(|e| e.into())
 }
 
+/// Registers the tool in the provided map.
 pub fn register(map: &mut HashMap<&'static str, Tool>) {
     let decl = declaration();
     map.insert(

--- a/src/tools/get_description.rs
+++ b/src/tools/get_description.rs
@@ -8,15 +8,18 @@ use std::collections::HashMap;
 
 const DECL_JSON: &str = include_str!("../../tools/get_description.json");
 
+/// Returns the function declaration for this tool.
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid get_description.json")
 }
 
+/// Reads `.taskter/description.md` and returns its contents.
 pub fn execute(_args: &Value) -> Result<String> {
     let content = fs::read_to_string(".taskter/description.md")?;
     Ok(content)
 }
 
+/// Registers the tool in the provided map.
 pub fn register(map: &mut HashMap<&'static str, Tool>) {
     map.insert(
         "get_description",

--- a/src/tools/list_agents.rs
+++ b/src/tools/list_agents.rs
@@ -7,15 +7,18 @@ use std::collections::HashMap;
 
 const DECL_JSON: &str = include_str!("../../tools/list_agents.json");
 
+/// Returns the function declaration for this tool.
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid list_agents.json")
 }
 
+/// Lists agents from `.taskter/agents.json`.
 pub fn execute(_args: &Value) -> Result<String> {
     let agents = agent::list_agents()?;
     Ok(serde_json::to_string_pretty(&agents)?)
 }
 
+/// Registers the tool in the provided map.
 pub fn register(map: &mut HashMap<&'static str, Tool>) {
     map.insert(
         "list_agents",

--- a/src/tools/list_tasks.rs
+++ b/src/tools/list_tasks.rs
@@ -8,15 +8,18 @@ use std::collections::HashMap;
 
 const DECL_JSON: &str = include_str!("../../tools/list_tasks.json");
 
+/// Returns the function declaration for this tool.
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid list_tasks.json")
 }
 
+/// Lists tasks stored in `.taskter/board.json`.
 pub fn execute(_args: &Value) -> Result<String> {
     let board = store::load_board()?;
     Ok(serde_json::to_string_pretty(&board.tasks)?)
 }
 
+/// Registers the tool in the provided map.
 pub fn register(map: &mut HashMap<&'static str, Tool>) {
     map.insert(
         "list_tasks",

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -16,11 +16,13 @@ pub mod list_tasks;
 pub mod run_bash;
 pub mod run_python;
 
+/// Runtime representation of a callable tool.
 pub struct Tool {
     pub declaration: FunctionDeclaration,
     pub execute: fn(&Value) -> Result<String>,
 }
 
+/// Registry of all tools bundled with Taskter.
 pub static BUILTIN_TOOLS: Lazy<HashMap<&'static str, Tool>> = Lazy::new(|| {
     let mut m = HashMap::new();
     add_log::register(&mut m);
@@ -43,10 +45,14 @@ pub fn builtin_names() -> Vec<&'static str> {
     names
 }
 
+/// Retrieves the declaration for a built-in tool by name.
 pub fn builtin_declaration(name: &str) -> Option<FunctionDeclaration> {
     BUILTIN_TOOLS.get(name).map(|t| t.declaration.clone())
 }
 
+/// Executes a named built-in tool.
+///
+/// Individual tools may read or write files in `.taskter/`.
 pub fn execute_tool(name: &str, args: &Value) -> Result<String> {
     if let Some(tool) = BUILTIN_TOOLS.get(name) {
         (tool.execute)(args)

--- a/src/tools/run_bash.rs
+++ b/src/tools/run_bash.rs
@@ -8,10 +8,12 @@ use std::collections::HashMap;
 
 const DECL_JSON: &str = include_str!("../../tools/run_bash.json");
 
+/// Returns the function declaration for this tool.
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid run_bash.json")
 }
 
+/// Runs a shell command using `sh -c`.
 pub fn execute(args: &Value) -> Result<String> {
     let command = args["command"]
         .as_str()
@@ -29,6 +31,7 @@ pub fn execute(args: &Value) -> Result<String> {
     }
 }
 
+/// Registers the tool in the provided map.
 pub fn register(map: &mut HashMap<&'static str, Tool>) {
     map.insert(
         "run_bash",

--- a/src/tools/run_python.rs
+++ b/src/tools/run_python.rs
@@ -8,10 +8,12 @@ use std::collections::HashMap;
 
 const DECL_JSON: &str = include_str!("../../tools/run_python.json");
 
+/// Returns the function declaration for this tool.
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid run_python.json")
 }
 
+/// Executes a Python snippet using the system `python3`.
 pub fn execute(args: &Value) -> Result<String> {
     let code = args["code"]
         .as_str()
@@ -29,6 +31,7 @@ pub fn execute(args: &Value) -> Result<String> {
     }
 }
 
+/// Registers the tool in the provided map.
 pub fn register(map: &mut HashMap<&'static str, Tool>) {
     map.insert(
         "run_python",


### PR DESCRIPTION
## Summary
- document public API for agents, store and tools
- mention how tool functions interact with files in `.taskter`
- clarify built in tool registry

## Testing
- `cargo doc --no-deps`

------
https://chatgpt.com/codex/tasks/task_e_687e44c9c4f08320b94fbea86e39e223