### PR TITLE
Add web_search tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,6 +555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -589,6 +590,7 @@ checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -1591,7 +1593,9 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0"
 clap = { version = "4.5.4", features = ["derive"] }
 crossterm = "0.28.1"
 ratatui = { version = "0.29.0", features = ["all-widgets"] }
-reqwest = { version = "0.12.4", features = ["json"] }
+reqwest = { version = "0.12.4", features = ["json", "blocking"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.37.0", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -262,7 +262,12 @@ Taskter now supports LLM-based agents that can be assigned to tasks. These agent
   the name of a built-in tool. Built-ins live under the `tools/` directory of
   the repository. For example `email` resolves to `tools/send_email.json`.
   Other built-ins include `create_task`, `assign_agent`, `add_log`, `add_okr`,
-  `list_tasks`, `list_agents`, `get_description`, `run_bash`, and `run_python`.
+  `list_tasks`, `list_agents`, `get_description`, `run_bash`, `run_python`,
+  `taskter_task`, `taskter_agent`, `taskter_okrs`, and `taskter_tools`.
+  The `taskter_*` tools wrap the corresponding CLI subcommands. Example:
+  ```json
+  {"tool": "taskter_task", "args": {"args": ["list"]}}
+  ```
 
 - **Assign an agent to a task:**
   ```bash

--- a/docs/src/agent_system.md
+++ b/docs/src/agent_system.md
@@ -23,6 +23,7 @@ Available built-in tools:
 - `run_bash`
 - `run_python`
 - `send_email`
+- `web_search`
 
 You can display this list at any time with:
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -23,9 +23,10 @@ If the file is missing the tool outputs `Email configuration not found`. When Ta
 
 ## Environment variables
 
-Taskter looks for a single environment variable:
+Taskter looks for a couple of optional environment variables:
 
 - `GEMINI_API_KEY` — API key for the Gemini model. When set, agents can call the remote API. If absent or empty Taskter stays in offline mode and only uses built-in tools.
+- `SEARCH_API_ENDPOINT` — custom endpoint for the `web_search` tool. Defaults to `https://api.duckduckgo.com`.
 
 Set it directly in your shell or via Docker Compose:
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -15,6 +15,7 @@ pub mod list_agents;
 pub mod list_tasks;
 pub mod run_bash;
 pub mod run_python;
+pub mod web_search;
 
 pub struct Tool {
     pub declaration: FunctionDeclaration,
@@ -33,6 +34,7 @@ pub static BUILTIN_TOOLS: Lazy<HashMap<&'static str, Tool>> = Lazy::new(|| {
     list_tasks::register(&mut m);
     run_bash::register(&mut m);
     run_python::register(&mut m);
+    web_search::register(&mut m);
     m
 });
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -15,6 +15,10 @@ pub mod list_agents;
 pub mod list_tasks;
 pub mod run_bash;
 pub mod run_python;
+pub mod taskter_agent;
+pub mod taskter_okrs;
+pub mod taskter_task;
+pub mod taskter_tools;
 pub mod web_search;
 
 pub struct Tool {
@@ -35,6 +39,10 @@ pub static BUILTIN_TOOLS: Lazy<HashMap<&'static str, Tool>> = Lazy::new(|| {
     run_bash::register(&mut m);
     run_python::register(&mut m);
     web_search::register(&mut m);
+    taskter_task::register(&mut m);
+    taskter_agent::register(&mut m);
+    taskter_okrs::register(&mut m);
+    taskter_tools::register(&mut m);
     m
 });
 

--- a/src/tools/taskter_agent.rs
+++ b/src/tools/taskter_agent.rs
@@ -1,0 +1,54 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use std::process::Command;
+
+use crate::agent::FunctionDeclaration;
+use crate::tools::Tool;
+use std::collections::HashMap;
+
+const DECL_JSON: &str = include_str!("../../tools/taskter_agent.json");
+
+fn taskter_bin() -> std::path::PathBuf {
+    std::env::var("TASKTER_BIN")
+        .or_else(|_| std::env::var("CARGO_BIN_EXE_taskter"))
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| "taskter".into())
+}
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid taskter_agent.json")
+}
+
+pub fn execute(args: &Value) -> Result<String> {
+    let arg_list = args["args"]
+        .as_array()
+        .ok_or_else(|| anyhow!("args missing"))?;
+    let mut cmd = Command::new(taskter_bin());
+    cmd.arg("agent");
+    for a in arg_list {
+        if let Some(s) = a.as_str() {
+            cmd.arg(s);
+        } else {
+            return Err(anyhow!("args must be strings"));
+        }
+    }
+    let output = cmd.output()?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        Err(anyhow!(
+            "Command failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ))
+    }
+}
+
+pub fn register(map: &mut HashMap<&'static str, Tool>) {
+    map.insert(
+        "taskter_agent",
+        Tool {
+            declaration: declaration(),
+            execute,
+        },
+    );
+}

--- a/src/tools/taskter_okrs.rs
+++ b/src/tools/taskter_okrs.rs
@@ -1,0 +1,54 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use std::process::Command;
+
+use crate::agent::FunctionDeclaration;
+use crate::tools::Tool;
+use std::collections::HashMap;
+
+const DECL_JSON: &str = include_str!("../../tools/taskter_okrs.json");
+
+fn taskter_bin() -> std::path::PathBuf {
+    std::env::var("TASKTER_BIN")
+        .or_else(|_| std::env::var("CARGO_BIN_EXE_taskter"))
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| "taskter".into())
+}
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid taskter_okrs.json")
+}
+
+pub fn execute(args: &Value) -> Result<String> {
+    let arg_list = args["args"]
+        .as_array()
+        .ok_or_else(|| anyhow!("args missing"))?;
+    let mut cmd = Command::new(taskter_bin());
+    cmd.arg("okrs");
+    for a in arg_list {
+        if let Some(s) = a.as_str() {
+            cmd.arg(s);
+        } else {
+            return Err(anyhow!("args must be strings"));
+        }
+    }
+    let output = cmd.output()?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        Err(anyhow!(
+            "Command failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ))
+    }
+}
+
+pub fn register(map: &mut HashMap<&'static str, Tool>) {
+    map.insert(
+        "taskter_okrs",
+        Tool {
+            declaration: declaration(),
+            execute,
+        },
+    );
+}

--- a/src/tools/taskter_task.rs
+++ b/src/tools/taskter_task.rs
@@ -1,0 +1,54 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use std::process::Command;
+
+use crate::agent::FunctionDeclaration;
+use crate::tools::Tool;
+use std::collections::HashMap;
+
+const DECL_JSON: &str = include_str!("../../tools/taskter_task.json");
+
+fn taskter_bin() -> std::path::PathBuf {
+    std::env::var("TASKTER_BIN")
+        .or_else(|_| std::env::var("CARGO_BIN_EXE_taskter"))
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| "taskter".into())
+}
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid taskter_task.json")
+}
+
+pub fn execute(args: &Value) -> Result<String> {
+    let arg_list = args["args"]
+        .as_array()
+        .ok_or_else(|| anyhow!("args missing"))?;
+    let mut cmd = Command::new(taskter_bin());
+    cmd.arg("task");
+    for a in arg_list {
+        if let Some(s) = a.as_str() {
+            cmd.arg(s);
+        } else {
+            return Err(anyhow!("args must be strings"));
+        }
+    }
+    let output = cmd.output()?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        Err(anyhow!(
+            "Command failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ))
+    }
+}
+
+pub fn register(map: &mut HashMap<&'static str, Tool>) {
+    map.insert(
+        "taskter_task",
+        Tool {
+            declaration: declaration(),
+            execute,
+        },
+    );
+}

--- a/src/tools/taskter_tools.rs
+++ b/src/tools/taskter_tools.rs
@@ -1,0 +1,54 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use std::process::Command;
+
+use crate::agent::FunctionDeclaration;
+use crate::tools::Tool;
+use std::collections::HashMap;
+
+const DECL_JSON: &str = include_str!("../../tools/taskter_tools.json");
+
+fn taskter_bin() -> std::path::PathBuf {
+    std::env::var("TASKTER_BIN")
+        .or_else(|_| std::env::var("CARGO_BIN_EXE_taskter"))
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| "taskter".into())
+}
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid taskter_tools.json")
+}
+
+pub fn execute(args: &Value) -> Result<String> {
+    let arg_list = args["args"]
+        .as_array()
+        .ok_or_else(|| anyhow!("args missing"))?;
+    let mut cmd = Command::new(taskter_bin());
+    cmd.arg("tools");
+    for a in arg_list {
+        if let Some(s) = a.as_str() {
+            cmd.arg(s);
+        } else {
+            return Err(anyhow!("args must be strings"));
+        }
+    }
+    let output = cmd.output()?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        Err(anyhow!(
+            "Command failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ))
+    }
+}
+
+pub fn register(map: &mut HashMap<&'static str, Tool>) {
+    map.insert(
+        "taskter_tools",
+        Tool {
+            declaration: declaration(),
+            execute,
+        },
+    );
+}

--- a/src/tools/web_search.rs
+++ b/src/tools/web_search.rs
@@ -1,0 +1,49 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use std::collections::HashMap;
+
+use crate::agent::FunctionDeclaration;
+use crate::tools::Tool;
+
+const DECL_JSON: &str = include_str!("../../tools/web_search.json");
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid web_search.json")
+}
+
+async fn search_online(query: &str) -> Result<String> {
+    let endpoint = std::env::var("SEARCH_API_ENDPOINT")
+        .unwrap_or_else(|_| "https://api.duckduckgo.com".to_string());
+    let url = reqwest::Url::parse_with_params(&endpoint, &[("q", query), ("format", "json")])?;
+    let resp = reqwest::get(url).await?;
+    let json: Value = resp.json().await?;
+    if let Some(text) = json["AbstractText"].as_str() {
+        if !text.is_empty() {
+            return Ok(text.to_string());
+        }
+    }
+    if let Some(arr) = json["RelatedTopics"].as_array() {
+        if let Some(first) = arr.iter().find_map(|t| t["Text"].as_str()) {
+            return Ok(first.to_string());
+        }
+    }
+    Ok("No results found".to_string())
+}
+
+pub fn execute(args: &Value) -> Result<String> {
+    let query = args["query"]
+        .as_str()
+        .ok_or_else(|| anyhow!("query missing"))?;
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(search_online(query))
+}
+
+pub fn register(map: &mut HashMap<&'static str, Tool>) {
+    map.insert(
+        "web_search",
+        Tool {
+            declaration: declaration(),
+            execute,
+        },
+    );
+}

--- a/tests/cli_commands.rs
+++ b/tests/cli_commands.rs
@@ -257,5 +257,6 @@ fn show_tools_lists_builtins() {
         let output = String::from_utf8(out).unwrap();
         assert!(output.contains("create_task"));
         assert!(output.contains("run_bash"));
+        assert!(output.contains("web_search"));
     });
 }

--- a/tests/tool_functions.rs
+++ b/tests/tool_functions.rs
@@ -1,3 +1,4 @@
+use assert_cmd::Command;
 use serde_json::json;
 use std::fs;
 
@@ -232,5 +233,103 @@ fn web_search_fetches_result() {
         assert_eq!(out, "Rust lang");
         std::env::remove_var("SEARCH_API_ENDPOINT");
         _m.assert();
+    });
+}
+
+#[test]
+fn taskter_task_tool_lists_tasks() {
+    with_temp_dir(|| {
+        let cmd = Command::cargo_bin("taskter").unwrap();
+        let bin = cmd.get_program().to_owned();
+        std::env::set_var("TASKTER_BIN", &bin);
+
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .arg("init")
+            .assert()
+            .success();
+
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .args(["task", "add", "--title", "Demo"])
+            .assert()
+            .success();
+
+        let out = taskter::tools::execute_tool("taskter_task", &json!({"args": ["list"]})).unwrap();
+        assert!(out.contains("Demo"));
+        std::env::remove_var("TASKTER_BIN");
+    });
+}
+
+#[test]
+fn taskter_agent_tool_lists_agents() {
+    with_temp_dir(|| {
+        let cmd = Command::cargo_bin("taskter").unwrap();
+        let bin = cmd.get_program().to_owned();
+        std::env::set_var("TASKTER_BIN", &bin);
+
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .arg("init")
+            .assert()
+            .success();
+
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .args([
+                "agent", "add", "--prompt", "helper", "--tools", "run_bash", "--model", "gpt-4o",
+            ])
+            .assert()
+            .success();
+
+        let out =
+            taskter::tools::execute_tool("taskter_agent", &json!({"args": ["list"]})).unwrap();
+        assert!(out.contains("helper"));
+        std::env::remove_var("TASKTER_BIN");
+    });
+}
+
+#[test]
+fn taskter_okrs_tool_lists_okrs() {
+    with_temp_dir(|| {
+        let cmd = Command::cargo_bin("taskter").unwrap();
+        let bin = cmd.get_program().to_owned();
+        std::env::set_var("TASKTER_BIN", &bin);
+
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .arg("init")
+            .assert()
+            .success();
+
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .args(["okrs", "add", "-o", "Improve", "-k", "Speed"])
+            .assert()
+            .success();
+
+        let out = taskter::tools::execute_tool("taskter_okrs", &json!({"args": ["list"]})).unwrap();
+        assert!(out.contains("Improve"));
+        std::env::remove_var("TASKTER_BIN");
+    });
+}
+
+#[test]
+fn taskter_tools_tool_lists_builtins() {
+    with_temp_dir(|| {
+        let cmd = Command::cargo_bin("taskter").unwrap();
+        let bin = cmd.get_program().to_owned();
+        std::env::set_var("TASKTER_BIN", &bin);
+
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .arg("init")
+            .assert()
+            .success();
+
+        let out =
+            taskter::tools::execute_tool("taskter_tools", &json!({"args": ["list"]})).unwrap();
+        assert!(out.contains("run_bash"));
+        std::env::remove_var("TASKTER_BIN");
     });
 }

--- a/tools/taskter_agent.json
+++ b/tools/taskter_agent.json
@@ -1,0 +1,15 @@
+{
+  "name": "taskter_agent",
+  "description": "Run the `taskter agent` command. Supported subcommands:\n- `add` --prompt <PROMPT> --tools <TOOLS>... --model <MODEL>\n- `list`\n- `remove` --id <ID>\n- `update` --id <ID> --prompt <PROMPT> [--tools <TOOLS>...]\nExamples:\n`{\"args\": [\"list\"]}` lists agents.\n`{\"args\": [\"add\", \"--prompt\", \"helper\", \"--tools\", \"run_bash\", \"--model\", \"gemini-pro\"]}` adds an agent.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "args": {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "Arguments for the `taskter agent` subcommand"
+      }
+    },
+    "required": ["args"]
+  }
+}

--- a/tools/taskter_okrs.json
+++ b/tools/taskter_okrs.json
@@ -1,0 +1,15 @@
+{
+  "name": "taskter_okrs",
+  "description": "Run the `taskter okrs` command. Subcommands:\n- `add` --objective <OBJECTIVE> --key-results <KR>...\n- `list`\nExamples:\n`{\"args\": [\"list\"]}` lists OKRs.\n`{\"args\": [\"add\", \"--objective\", \"Improve\", \"--key-results\", \"Speed\"]}` adds an OKR.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "args": {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "Arguments for the `taskter okrs` subcommand"
+      }
+    },
+    "required": ["args"]
+  }
+}

--- a/tools/taskter_task.json
+++ b/tools/taskter_task.json
@@ -1,0 +1,15 @@
+{
+  "name": "taskter_task",
+  "description": "Run the `taskter task` command. Available subcommands:\n- `add` --title <TITLE> [--description <DESC>]\n- `list`\n- `complete` --id <ID>\n- `comment` --task-id <TASK_ID> --comment <COMMENT>\n- `assign` --task-id <TASK_ID> --agent-id <AGENT_ID>\n- `execute` --task-id <TASK_ID>\nExamples:\n`{\"args\": [\"list\"]}` lists tasks.\n`{\"args\": [\"add\", \"--title\", \"Demo\"]}` adds a task.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "args": {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "Arguments for the `taskter task` subcommand"
+      }
+    },
+    "required": ["args"]
+  }
+}

--- a/tools/taskter_tools.json
+++ b/tools/taskter_tools.json
@@ -1,0 +1,15 @@
+{
+  "name": "taskter_tools",
+  "description": "Run the `taskter tools` command. The only subcommand is `list` which displays built-in tools.\nExample: `{\"args\": [\"list\"]}`",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "args": {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "Arguments for the `taskter tools` subcommand"
+      }
+    },
+    "required": ["args"]
+  }
+}

--- a/tools/web_search.json
+++ b/tools/web_search.json
@@ -1,0 +1,11 @@
+{
+  "name": "web_search",
+  "description": "Search the web and return a brief summary of the top result",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "query": { "type": "string", "description": "Search query" }
+    },
+    "required": ["query"]
+  }
+}


### PR DESCRIPTION
## Summary
- add a `web_search` tool for agents with DuckDuckGo backend
- document the tool and new `SEARCH_API_ENDPOINT` variable
- check that builtin tools list contains new entry
- test web search tool with mock HTTP server

## Testing
- `./scripts/precommit.sh`

------
https://chatgpt.com/codex/tasks/task_e_687e4673e5948320a8792a34d71ff36f