### PR TITLE
Add taskter CLI wrapper tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,12 @@ Taskter now supports LLM-based agents that can be assigned to tasks. These agent
   the name of a built-in tool. Built-ins live under the `tools/` directory of
   the repository. For example `email` resolves to `tools/send_email.json`.
   Other built-ins include `create_task`, `assign_agent`, `add_log`, `add_okr`,
-  `list_tasks`, `list_agents`, `get_description`, `run_bash`, and `run_python`.
+  `list_tasks`, `list_agents`, `get_description`, `run_bash`, `run_python`,
+  `taskter_task`, `taskter_agent`, `taskter_okrs`, and `taskter_tools`.
+  The `taskter_*` tools wrap the corresponding CLI subcommands. Example:
+  ```json
+  {"tool": "taskter_task", "args": {"args": ["list"]}}
+  ```
 
 - **Assign an agent to a task:**
   ```bash

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -15,6 +15,10 @@ pub mod list_agents;
 pub mod list_tasks;
 pub mod run_bash;
 pub mod run_python;
+pub mod taskter_agent;
+pub mod taskter_okrs;
+pub mod taskter_task;
+pub mod taskter_tools;
 pub mod web_search;
 
 pub struct Tool {
@@ -35,6 +39,10 @@ pub static BUILTIN_TOOLS: Lazy<HashMap<&'static str, Tool>> = Lazy::new(|| {
     run_bash::register(&mut m);
     run_python::register(&mut m);
     web_search::register(&mut m);
+    taskter_task::register(&mut m);
+    taskter_agent::register(&mut m);
+    taskter_okrs::register(&mut m);
+    taskter_tools::register(&mut m);
     m
 });
 

--- a/src/tools/taskter_agent.rs
+++ b/src/tools/taskter_agent.rs
@@ -1,0 +1,54 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use std::process::Command;
+
+use crate::agent::FunctionDeclaration;
+use crate::tools::Tool;
+use std::collections::HashMap;
+
+const DECL_JSON: &str = include_str!("../../tools/taskter_agent.json");
+
+fn taskter_bin() -> std::path::PathBuf {
+    std::env::var("TASKTER_BIN")
+        .or_else(|_| std::env::var("CARGO_BIN_EXE_taskter"))
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| "taskter".into())
+}
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid taskter_agent.json")
+}
+
+pub fn execute(args: &Value) -> Result<String> {
+    let arg_list = args["args"]
+        .as_array()
+        .ok_or_else(|| anyhow!("args missing"))?;
+    let mut cmd = Command::new(taskter_bin());
+    cmd.arg("agent");
+    for a in arg_list {
+        if let Some(s) = a.as_str() {
+            cmd.arg(s);
+        } else {
+            return Err(anyhow!("args must be strings"));
+        }
+    }
+    let output = cmd.output()?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        Err(anyhow!(
+            "Command failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ))
+    }
+}
+
+pub fn register(map: &mut HashMap<&'static str, Tool>) {
+    map.insert(
+        "taskter_agent",
+        Tool {
+            declaration: declaration(),
+            execute,
+        },
+    );
+}

--- a/src/tools/taskter_okrs.rs
+++ b/src/tools/taskter_okrs.rs
@@ -1,0 +1,54 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use std::process::Command;
+
+use crate::agent::FunctionDeclaration;
+use crate::tools::Tool;
+use std::collections::HashMap;
+
+const DECL_JSON: &str = include_str!("../../tools/taskter_okrs.json");
+
+fn taskter_bin() -> std::path::PathBuf {
+    std::env::var("TASKTER_BIN")
+        .or_else(|_| std::env::var("CARGO_BIN_EXE_taskter"))
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| "taskter".into())
+}
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid taskter_okrs.json")
+}
+
+pub fn execute(args: &Value) -> Result<String> {
+    let arg_list = args["args"]
+        .as_array()
+        .ok_or_else(|| anyhow!("args missing"))?;
+    let mut cmd = Command::new(taskter_bin());
+    cmd.arg("okrs");
+    for a in arg_list {
+        if let Some(s) = a.as_str() {
+            cmd.arg(s);
+        } else {
+            return Err(anyhow!("args must be strings"));
+        }
+    }
+    let output = cmd.output()?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        Err(anyhow!(
+            "Command failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ))
+    }
+}
+
+pub fn register(map: &mut HashMap<&'static str, Tool>) {
+    map.insert(
+        "taskter_okrs",
+        Tool {
+            declaration: declaration(),
+            execute,
+        },
+    );
+}

--- a/src/tools/taskter_task.rs
+++ b/src/tools/taskter_task.rs
@@ -1,0 +1,54 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use std::process::Command;
+
+use crate::agent::FunctionDeclaration;
+use crate::tools::Tool;
+use std::collections::HashMap;
+
+const DECL_JSON: &str = include_str!("../../tools/taskter_task.json");
+
+fn taskter_bin() -> std::path::PathBuf {
+    std::env::var("TASKTER_BIN")
+        .or_else(|_| std::env::var("CARGO_BIN_EXE_taskter"))
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| "taskter".into())
+}
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid taskter_task.json")
+}
+
+pub fn execute(args: &Value) -> Result<String> {
+    let arg_list = args["args"]
+        .as_array()
+        .ok_or_else(|| anyhow!("args missing"))?;
+    let mut cmd = Command::new(taskter_bin());
+    cmd.arg("task");
+    for a in arg_list {
+        if let Some(s) = a.as_str() {
+            cmd.arg(s);
+        } else {
+            return Err(anyhow!("args must be strings"));
+        }
+    }
+    let output = cmd.output()?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        Err(anyhow!(
+            "Command failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ))
+    }
+}
+
+pub fn register(map: &mut HashMap<&'static str, Tool>) {
+    map.insert(
+        "taskter_task",
+        Tool {
+            declaration: declaration(),
+            execute,
+        },
+    );
+}

--- a/src/tools/taskter_tools.rs
+++ b/src/tools/taskter_tools.rs
@@ -1,0 +1,54 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use std::process::Command;
+
+use crate::agent::FunctionDeclaration;
+use crate::tools::Tool;
+use std::collections::HashMap;
+
+const DECL_JSON: &str = include_str!("../../tools/taskter_tools.json");
+
+fn taskter_bin() -> std::path::PathBuf {
+    std::env::var("TASKTER_BIN")
+        .or_else(|_| std::env::var("CARGO_BIN_EXE_taskter"))
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| "taskter".into())
+}
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid taskter_tools.json")
+}
+
+pub fn execute(args: &Value) -> Result<String> {
+    let arg_list = args["args"]
+        .as_array()
+        .ok_or_else(|| anyhow!("args missing"))?;
+    let mut cmd = Command::new(taskter_bin());
+    cmd.arg("tools");
+    for a in arg_list {
+        if let Some(s) = a.as_str() {
+            cmd.arg(s);
+        } else {
+            return Err(anyhow!("args must be strings"));
+        }
+    }
+    let output = cmd.output()?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        Err(anyhow!(
+            "Command failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ))
+    }
+}
+
+pub fn register(map: &mut HashMap<&'static str, Tool>) {
+    map.insert(
+        "taskter_tools",
+        Tool {
+            declaration: declaration(),
+            execute,
+        },
+    );
+}

--- a/tests/tool_functions.rs
+++ b/tests/tool_functions.rs
@@ -1,3 +1,4 @@
+use assert_cmd::Command;
 use serde_json::json;
 use std::fs;
 
@@ -232,5 +233,103 @@ fn web_search_fetches_result() {
         assert_eq!(out, "Rust lang");
         std::env::remove_var("SEARCH_API_ENDPOINT");
         _m.assert();
+    });
+}
+
+#[test]
+fn taskter_task_tool_lists_tasks() {
+    with_temp_dir(|| {
+        let cmd = Command::cargo_bin("taskter").unwrap();
+        let bin = cmd.get_program().to_owned();
+        std::env::set_var("TASKTER_BIN", &bin);
+
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .arg("init")
+            .assert()
+            .success();
+
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .args(["task", "add", "--title", "Demo"])
+            .assert()
+            .success();
+
+        let out = taskter::tools::execute_tool("taskter_task", &json!({"args": ["list"]})).unwrap();
+        assert!(out.contains("Demo"));
+        std::env::remove_var("TASKTER_BIN");
+    });
+}
+
+#[test]
+fn taskter_agent_tool_lists_agents() {
+    with_temp_dir(|| {
+        let cmd = Command::cargo_bin("taskter").unwrap();
+        let bin = cmd.get_program().to_owned();
+        std::env::set_var("TASKTER_BIN", &bin);
+
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .arg("init")
+            .assert()
+            .success();
+
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .args([
+                "agent", "add", "--prompt", "helper", "--tools", "run_bash", "--model", "gpt-4o",
+            ])
+            .assert()
+            .success();
+
+        let out =
+            taskter::tools::execute_tool("taskter_agent", &json!({"args": ["list"]})).unwrap();
+        assert!(out.contains("helper"));
+        std::env::remove_var("TASKTER_BIN");
+    });
+}
+
+#[test]
+fn taskter_okrs_tool_lists_okrs() {
+    with_temp_dir(|| {
+        let cmd = Command::cargo_bin("taskter").unwrap();
+        let bin = cmd.get_program().to_owned();
+        std::env::set_var("TASKTER_BIN", &bin);
+
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .arg("init")
+            .assert()
+            .success();
+
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .args(["okrs", "add", "-o", "Improve", "-k", "Speed"])
+            .assert()
+            .success();
+
+        let out = taskter::tools::execute_tool("taskter_okrs", &json!({"args": ["list"]})).unwrap();
+        assert!(out.contains("Improve"));
+        std::env::remove_var("TASKTER_BIN");
+    });
+}
+
+#[test]
+fn taskter_tools_tool_lists_builtins() {
+    with_temp_dir(|| {
+        let cmd = Command::cargo_bin("taskter").unwrap();
+        let bin = cmd.get_program().to_owned();
+        std::env::set_var("TASKTER_BIN", &bin);
+
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .arg("init")
+            .assert()
+            .success();
+
+        let out =
+            taskter::tools::execute_tool("taskter_tools", &json!({"args": ["list"]})).unwrap();
+        assert!(out.contains("run_bash"));
+        std::env::remove_var("TASKTER_BIN");
     });
 }

--- a/tools/taskter_agent.json
+++ b/tools/taskter_agent.json
@@ -1,0 +1,15 @@
+{
+  "name": "taskter_agent",
+  "description": "Run the `taskter agent` command. Supported subcommands:\n- `add` --prompt <PROMPT> --tools <TOOLS>... --model <MODEL>\n- `list`\n- `remove` --id <ID>\n- `update` --id <ID> --prompt <PROMPT> [--tools <TOOLS>...]\nExamples:\n`{\"args\": [\"list\"]}` lists agents.\n`{\"args\": [\"add\", \"--prompt\", \"helper\", \"--tools\", \"run_bash\", \"--model\", \"gemini-pro\"]}` adds an agent.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "args": {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "Arguments for the `taskter agent` subcommand"
+      }
+    },
+    "required": ["args"]
+  }
+}

--- a/tools/taskter_okrs.json
+++ b/tools/taskter_okrs.json
@@ -1,0 +1,15 @@
+{
+  "name": "taskter_okrs",
+  "description": "Run the `taskter okrs` command. Subcommands:\n- `add` --objective <OBJECTIVE> --key-results <KR>...\n- `list`\nExamples:\n`{\"args\": [\"list\"]}` lists OKRs.\n`{\"args\": [\"add\", \"--objective\", \"Improve\", \"--key-results\", \"Speed\"]}` adds an OKR.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "args": {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "Arguments for the `taskter okrs` subcommand"
+      }
+    },
+    "required": ["args"]
+  }
+}

--- a/tools/taskter_task.json
+++ b/tools/taskter_task.json
@@ -1,0 +1,15 @@
+{
+  "name": "taskter_task",
+  "description": "Run the `taskter task` command. Available subcommands:\n- `add` --title <TITLE> [--description <DESC>]\n- `list`\n- `complete` --id <ID>\n- `comment` --task-id <TASK_ID> --comment <COMMENT>\n- `assign` --task-id <TASK_ID> --agent-id <AGENT_ID>\n- `execute` --task-id <TASK_ID>\nExamples:\n`{\"args\": [\"list\"]}` lists tasks.\n`{\"args\": [\"add\", \"--title\", \"Demo\"]}` adds a task.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "args": {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "Arguments for the `taskter task` subcommand"
+      }
+    },
+    "required": ["args"]
+  }
+}

--- a/tools/taskter_tools.json
+++ b/tools/taskter_tools.json
@@ -1,0 +1,15 @@
+{
+  "name": "taskter_tools",
+  "description": "Run the `taskter tools` command. The only subcommand is `list` which displays built-in tools.\nExample: `{\"args\": [\"list\"]}`",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "args": {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "Arguments for the `taskter tools` subcommand"
+      }
+    },
+    "required": ["args"]
+  }
+}


### PR DESCRIPTION
## Summary
- add new builtin tools that invoke `taskter` CLI subcommands
- register new `taskter_*` tools
- document the new tools
- test calling taskter CLI through new tools
- improve tool descriptions

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687e555f45d483208ffa82e6e7af2055