### PR TITLE
Add TUI interaction and error handling tests

### DIFF
--- a/scripts/precommit.sh
+++ b/scripts/precommit.sh
@@ -6,7 +6,7 @@ cargo fmt --all -- --check || exit 1
 # Lint code with clippy
 cargo clippy --all-targets --all-features -- -D warnings || exit 1
 
-# Run tests
-cargo test || exit 1
+# Run tests with all features
+cargo test --all-features || exit 1
 
 exit 0

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -3,3 +3,6 @@ mod handlers;
 mod render;
 
 pub use handlers::run_tui;
+
+#[cfg(test)]
+mod tests;

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1,0 +1,112 @@
+#[cfg(feature = "tui")]
+use super::app::{App, View};
+#[cfg(feature = "tui")]
+use crate::agent::{self, Agent, ExecutionResult};
+#[cfg(feature = "tui")]
+use crate::store::{Board, Task, TaskStatus};
+#[cfg(feature = "tui")]
+use std::sync::Arc;
+
+#[cfg(feature = "tui")]
+fn sample_task() -> Task {
+    Task {
+        id: 1,
+        title: "sample".into(),
+        description: None,
+        status: TaskStatus::ToDo,
+        agent_id: None,
+        comment: None,
+    }
+}
+
+#[cfg(feature = "tui")]
+#[test]
+fn navigation_and_move_task() {
+    let board = Board {
+        tasks: vec![sample_task()],
+    };
+    let mut app = App::new(board, Vec::new());
+
+    assert_eq!(app.selected_column, 0);
+    assert_eq!(app.get_selected_task().unwrap().id, 1);
+
+    app.move_task_to_next_column();
+    assert_eq!(
+        app.board.lock().unwrap().tasks[0].status,
+        TaskStatus::InProgress
+    );
+
+    app.next_column();
+    assert_eq!(app.selected_column, 1);
+    app.move_task_to_prev_column();
+    assert_eq!(app.board.lock().unwrap().tasks[0].status, TaskStatus::ToDo);
+}
+
+#[cfg(feature = "tui")]
+#[test]
+fn add_comment_flow() {
+    let board = Board {
+        tasks: vec![sample_task()],
+    };
+    let mut app = App::new(board, Vec::new());
+    app.current_view = View::AddComment;
+    app.comment_input = "note".to_string();
+
+    if let Some(task_id) = app.get_selected_task().map(|t| t.id) {
+        if let Some(task) = app
+            .board
+            .lock()
+            .unwrap()
+            .tasks
+            .iter_mut()
+            .find(|t| t.id == task_id)
+        {
+            task.comment = Some(app.comment_input.clone());
+        }
+    }
+
+    assert_eq!(
+        app.board.lock().unwrap().tasks[0].comment.as_deref(),
+        Some("note")
+    );
+}
+
+#[cfg(feature = "tui")]
+#[tokio::test]
+async fn assign_agent_failure_updates_task() {
+    let mut task = sample_task();
+    task.agent_id = Some(1);
+    let board = Board { tasks: vec![task] };
+    let agent = Agent {
+        id: 1,
+        system_prompt: "helper".into(),
+        tools: Vec::new(),
+        model: "gpt-4o".into(),
+    };
+    let app = App::new(board, vec![agent.clone()]);
+    let agent_clone = agent.clone();
+    let task_clone = app.get_selected_task().unwrap();
+    let board_clone = Arc::clone(&app.board);
+
+    let result = agent::execute_task(&agent_clone, &task_clone)
+        .await
+        .unwrap();
+    let mut board = board_clone.lock().unwrap();
+    if let Some(t) = board.tasks.iter_mut().find(|t| t.id == task_clone.id) {
+        match result {
+            ExecutionResult::Success { comment } => {
+                t.status = TaskStatus::Done;
+                t.comment = Some(comment);
+            }
+            ExecutionResult::Failure { comment } => {
+                t.status = TaskStatus::ToDo;
+                t.comment = Some(comment);
+                t.agent_id = None;
+            }
+        }
+    }
+
+    assert!(board.tasks[0].comment.is_some());
+    assert_eq!(board.tasks[0].status, TaskStatus::ToDo);
+    assert_eq!(board.tasks[0].agent_id, None);
+}

--- a/tests/tool_functions.rs
+++ b/tests/tool_functions.rs
@@ -210,3 +210,33 @@ fn get_description_fails_missing_file() {
         assert!(err.to_string().contains("No such file"));
     });
 }
+
+#[test]
+fn run_bash_reports_error() {
+    with_temp_dir(|| {
+        let err = taskter::tools::run_bash::execute(&json!({"command": "exit 1"})).unwrap_err();
+        assert!(err.to_string().contains("Command failed"));
+    });
+}
+
+#[test]
+fn run_python_reports_error() {
+    with_temp_dir(|| {
+        let err = taskter::tools::run_python::execute(&json!({"code": "import sys; sys.exit(1)"}))
+            .unwrap_err();
+        assert!(err.to_string().contains("Python execution failed"));
+    });
+}
+
+#[test]
+fn send_email_fails_without_config() {
+    with_temp_dir(|| {
+        let msg = taskter::tools::email::execute(&json!({
+            "to": "a@example.com",
+            "subject": "hi",
+            "body": "test"
+        }))
+        .unwrap();
+        assert!(msg.contains("Failed to send email"));
+    });
+}


### PR DESCRIPTION
## Summary
- add test module for TUI features behind `tui` feature flag
- cover navigation, comment flow and agent failure logic
- add negative tests for `run_bash`, `run_python` and `send_email`
- run tests with all features in precommit script

## Testing
- `./scripts/precommit.sh`

------
https://chatgpt.com/codex/tasks/task_e_687da1591e9c8320bcad237a4f09466d