### PR TITLE
Add file_ops built-in tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,8 @@ Taskter now supports LLM-based agents that can be assigned to tasks. These agent
   the repository. For example `email` resolves to `tools/send_email.json`.
   Other built-ins include `create_task`, `assign_agent`, `add_log`, `add_okr`,
   `list_tasks`, `list_agents`, `get_description`, `run_bash`, `run_python`,
-  `taskter_task`, `taskter_agent`, `taskter_okrs`, and `taskter_tools`.
+  `file_ops`, `taskter_task`, `taskter_agent`, `taskter_okrs`, and
+  `taskter_tools`.
   The `taskter_*` tools wrap the corresponding CLI subcommands. Example:
   ```json
   {"tool": "taskter_task", "args": {"args": ["list"]}}

--- a/docs/src/agent_system.md
+++ b/docs/src/agent_system.md
@@ -22,6 +22,7 @@ Available built-in tools:
 - `get_description`
 - `run_bash`
 - `run_python`
+- `file_ops`
 - `send_email`
 - `web_search`
 

--- a/src/tools/file_ops.rs
+++ b/src/tools/file_ops.rs
@@ -1,0 +1,62 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::fs;
+
+use crate::agent::FunctionDeclaration;
+use crate::tools::Tool;
+
+const DECL_JSON: &str = include_str!("../../tools/file_ops.json");
+
+/// Returns the function declaration for this tool.
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid file_ops.json")
+}
+
+/// Performs basic file operations in the project directory.
+pub fn execute(args: &Value) -> Result<String> {
+    let action = args["action"]
+        .as_str()
+        .ok_or_else(|| anyhow!("action missing"))?;
+    let path = args["path"]
+        .as_str()
+        .ok_or_else(|| anyhow!("path missing"))?;
+    match action {
+        "read" => {
+            let content = fs::read_to_string(path)?;
+            Ok(content)
+        }
+        "write" => {
+            let text = args["text"]
+                .as_str()
+                .ok_or_else(|| anyhow!("text missing"))?;
+            fs::write(path, text)?;
+            Ok("File written".to_string())
+        }
+        "search" => {
+            let query = args["text"]
+                .as_str()
+                .ok_or_else(|| anyhow!("text missing"))?;
+            let content = fs::read_to_string(path)?;
+            let mut matches = Vec::new();
+            for (i, line) in content.lines().enumerate() {
+                if line.contains(query) {
+                    matches.push(format!("{}: {}", i + 1, line));
+                }
+            }
+            Ok(matches.join("\n"))
+        }
+        _ => Err(anyhow!("unknown action")),
+    }
+}
+
+/// Registers the tool in the provided map.
+pub fn register(map: &mut HashMap<&'static str, Tool>) {
+    map.insert(
+        "file_ops",
+        Tool {
+            declaration: declaration(),
+            execute,
+        },
+    );
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -10,6 +10,7 @@ pub mod add_okr;
 pub mod assign_agent;
 pub mod create_task;
 pub mod email;
+pub mod file_ops;
 pub mod get_description;
 pub mod list_agents;
 pub mod list_tasks;
@@ -40,6 +41,7 @@ pub static BUILTIN_TOOLS: Lazy<HashMap<&'static str, Tool>> = Lazy::new(|| {
     list_tasks::register(&mut m);
     run_bash::register(&mut m);
     run_python::register(&mut m);
+    file_ops::register(&mut m);
     web_search::register(&mut m);
     taskter_task::register(&mut m);
     taskter_agent::register(&mut m);

--- a/tests/cli_commands.rs
+++ b/tests/cli_commands.rs
@@ -261,6 +261,7 @@ fn show_tools_lists_builtins() {
         let output = String::from_utf8(out).unwrap();
         assert!(output.contains("create_task"));
         assert!(output.contains("run_bash"));
+        assert!(output.contains("file_ops"));
         assert!(output.contains("web_search"));
     });
 }

--- a/tests/tool_functions.rs
+++ b/tests/tool_functions.rs
@@ -330,6 +330,7 @@ fn taskter_tools_tool_lists_builtins() {
         let out =
             taskter::tools::execute_tool("taskter_tools", &json!({"args": ["list"]})).unwrap();
         assert!(out.contains("run_bash"));
+        assert!(out.contains("file_ops"));
         std::env::remove_var("TASKTER_BIN");
     });
 }

--- a/tools/file_ops.json
+++ b/tools/file_ops.json
@@ -1,0 +1,18 @@
+{
+  "name": "file_ops",
+  "description": "Read, search, update or create text files in the project directory",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "action": {
+        "type": "string",
+        "enum": ["read", "write", "search"],
+        "description": "Operation to perform"
+      },
+      "path": { "type": "string", "description": "Relative path to the text file" },
+      "text": { "type": "string", "description": "Text to write or search for" }
+    },
+    "required": ["action", "path"],
+    "additionalProperties": false
+  }
+}


### PR DESCRIPTION
## Summary
- add `file_ops` tool for reading, searching and writing text files
- register the tool with the built-in registry
- document the new tool in README and docs
- check for `file_ops` in tool listing tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687edecb97988320a82dd2ff733bffc6