### PR TITLE
Add file_manager tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,6 +1999,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ lettre = "0.11.17"
 chrono = { version = "0.4", features = ["serde"] }
 notify = "8.1"
 once_cell = "1.19"
+walkdir = "2.5.0"
 [features]
 tui = []
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -264,7 +264,8 @@ Taskter now supports LLM-based agents that can be assigned to tasks. These agent
   the repository. For example `email` resolves to `tools/send_email.json`.
   Other built-ins include `create_task`, `assign_agent`, `add_log`, `add_okr`,
   `list_tasks`, `list_agents`, `get_description`, `run_bash`, `run_python`,
-  `taskter_task`, `taskter_agent`, `taskter_okrs`, and `taskter_tools`.
+  `send_email`, `web_search`, `file_manager`, `taskter_task`, `taskter_agent`,
+  `taskter_okrs`, and `taskter_tools`.
   The `taskter_*` tools wrap the corresponding CLI subcommands. Example:
   ```json
   {"tool": "taskter_task", "args": {"args": ["list"]}}

--- a/docs/src/agent_system.md
+++ b/docs/src/agent_system.md
@@ -24,6 +24,7 @@ Available built-in tools:
 - `run_python`
 - `send_email`
 - `web_search`
+- `file_manager`
 
 You can display this list at any time with:
 

--- a/src/tools/file_manager.rs
+++ b/src/tools/file_manager.rs
@@ -1,0 +1,74 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::fs;
+
+use crate::agent::FunctionDeclaration;
+use crate::tools::Tool;
+
+const DECL_JSON: &str = include_str!("../../tools/file_manager.json");
+
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid file_manager.json")
+}
+
+pub fn execute(args: &Value) -> Result<String> {
+    let action = args["action"]
+        .as_str()
+        .ok_or_else(|| anyhow!("action missing"))?;
+    match action {
+        "read" => {
+            let path = args["path"]
+                .as_str()
+                .ok_or_else(|| anyhow!("path missing"))?;
+            let content = fs::read_to_string(path)?;
+            Ok(content)
+        }
+        "create" => {
+            let path = args["path"]
+                .as_str()
+                .ok_or_else(|| anyhow!("path missing"))?;
+            let content = args["content"].as_str().unwrap_or_default();
+            fs::write(path, content)?;
+            Ok(format!("File {path} created"))
+        }
+        "update" => {
+            let path = args["path"]
+                .as_str()
+                .ok_or_else(|| anyhow!("path missing"))?;
+            let content = args["content"]
+                .as_str()
+                .ok_or_else(|| anyhow!("content missing"))?;
+            fs::write(path, content)?;
+            Ok(format!("File {path} updated"))
+        }
+        "search" => {
+            let query = args["query"]
+                .as_str()
+                .ok_or_else(|| anyhow!("query missing"))?;
+            let mut matches = Vec::new();
+            for entry in walkdir::WalkDir::new(".") {
+                let entry = entry?;
+                if entry.file_type().is_file() {
+                    if let Ok(content) = fs::read_to_string(entry.path()) {
+                        if content.contains(query) {
+                            matches.push(entry.path().display().to_string());
+                        }
+                    }
+                }
+            }
+            Ok(serde_json::to_string(&matches)?)
+        }
+        other => Err(anyhow!("Unknown action: {other}")),
+    }
+}
+
+pub fn register(map: &mut HashMap<&'static str, Tool>) {
+    map.insert(
+        "file_manager",
+        Tool {
+            declaration: declaration(),
+            execute,
+        },
+    );
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -10,6 +10,7 @@ pub mod add_okr;
 pub mod assign_agent;
 pub mod create_task;
 pub mod email;
+pub mod file_manager;
 pub mod get_description;
 pub mod list_agents;
 pub mod list_tasks;
@@ -40,6 +41,7 @@ pub static BUILTIN_TOOLS: Lazy<HashMap<&'static str, Tool>> = Lazy::new(|| {
     list_tasks::register(&mut m);
     run_bash::register(&mut m);
     run_python::register(&mut m);
+    file_manager::register(&mut m);
     web_search::register(&mut m);
     taskter_task::register(&mut m);
     taskter_agent::register(&mut m);

--- a/tests/tool_functions.rs
+++ b/tests/tool_functions.rs
@@ -333,3 +333,36 @@ fn taskter_tools_tool_lists_builtins() {
         std::env::remove_var("TASKTER_BIN");
     });
 }
+
+#[test]
+fn file_manager_create_and_read() {
+    with_temp_dir(|| {
+        taskter::tools::execute_tool(
+            "file_manager",
+            &json!({"action": "create", "path": "note.txt", "content": "hello"}),
+        )
+        .unwrap();
+        let out = taskter::tools::execute_tool(
+            "file_manager",
+            &json!({"action": "read", "path": "note.txt"}),
+        )
+        .unwrap();
+        assert_eq!(out, "hello");
+    });
+}
+
+#[test]
+fn file_manager_search_finds_files() {
+    with_temp_dir(|| {
+        std::fs::write("a.txt", "search me").unwrap();
+        std::fs::write("b.txt", "nothing").unwrap();
+        let out = taskter::tools::execute_tool(
+            "file_manager",
+            &json!({"action": "search", "query": "search"}),
+        )
+        .unwrap();
+        let paths: Vec<String> = serde_json::from_str(&out).unwrap();
+        assert!(paths.iter().any(|p| p.ends_with("a.txt")));
+        assert!(!paths.iter().any(|p| p.ends_with("b.txt")));
+    });
+}

--- a/tools/file_manager.json
+++ b/tools/file_manager.json
@@ -1,0 +1,14 @@
+{
+  "name": "file_manager",
+  "description": "Create, read, search, and update text files in the project directory",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "action": { "type": "string", "description": "One of: create, read, update, search" },
+      "path": { "type": "string", "description": "File path for create, read or update" },
+      "content": { "type": "string", "description": "Content for create or update" },
+      "query": { "type": "string", "description": "Text to search for" }
+    },
+    "required": ["action"]
+  }
+}


### PR DESCRIPTION
## Summary
- add `file_manager` built-in tool for working with text files
- register the tool and document it
- include tests for the new tool
- mention new tool in README
- depend on `walkdir` crate

## Testing
- `./scripts/precommit.sh`

------
https://chatgpt.com/codex/tasks/task_e_687ee8d475008320832c770311654971