### PR TITLE
Add TUI and failure tests

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4,7 +4,7 @@ use ratatui::widgets::ListState;
 use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Copy)]
-pub(crate) enum View {
+pub enum View {
     Board,
     TaskDescription,
     AssignAgent,
@@ -17,24 +17,24 @@ pub(crate) enum View {
     Commands,
 }
 
-pub(crate) struct App {
-    pub(crate) board: Arc<Mutex<Board>>,
-    pub(crate) agents: Vec<Agent>,
-    pub(crate) selected_column: usize,
-    pub(crate) selected_task: [ListState; 3],
-    pub(crate) current_view: View,
-    pub(crate) agent_list_state: ListState,
-    pub(crate) comment_input: String,
-    pub(crate) new_task_title: String,
-    pub(crate) new_task_description: String,
-    pub(crate) editing_description: bool,
-    pub(crate) logs: String,
-    pub(crate) okrs: Vec<Okr>,
-    pub(crate) popup_scroll: u16,
+pub struct App {
+    pub board: Arc<Mutex<Board>>,
+    pub agents: Vec<Agent>,
+    pub selected_column: usize,
+    pub selected_task: [ListState; 3],
+    pub current_view: View,
+    pub agent_list_state: ListState,
+    pub comment_input: String,
+    pub new_task_title: String,
+    pub new_task_description: String,
+    pub editing_description: bool,
+    pub logs: String,
+    pub okrs: Vec<Okr>,
+    pub popup_scroll: u16,
 }
 
 impl App {
-    pub(crate) fn new(board: Board, agents: Vec<Agent>) -> Self {
+    pub fn new(board: Board, agents: Vec<Agent>) -> Self {
         let mut app = App {
             board: Arc::new(Mutex::new(board)),
             agents,
@@ -58,12 +58,12 @@ impl App {
         app
     }
 
-    pub(crate) fn next_column(&mut self) {
+    pub fn next_column(&mut self) {
         self.selected_column = (self.selected_column + 1) % 3;
         self.ensure_selected_task();
     }
 
-    pub(crate) fn prev_column(&mut self) {
+    pub fn prev_column(&mut self) {
         self.selected_column = (self.selected_column + 2) % 3;
         self.ensure_selected_task();
     }
@@ -79,7 +79,7 @@ impl App {
         }
     }
 
-    pub(crate) fn next_task(&mut self) {
+    pub fn next_task(&mut self) {
         let tasks = self.tasks_in_current_column();
         if tasks.is_empty() {
             return;
@@ -91,7 +91,7 @@ impl App {
         self.selected_task[self.selected_column].select(Some(i));
     }
 
-    pub(crate) fn prev_task(&mut self) {
+    pub fn prev_task(&mut self) {
         let tasks = self.tasks_in_current_column();
         if tasks.is_empty() {
             return;
@@ -103,7 +103,7 @@ impl App {
         self.selected_task[self.selected_column].select(Some(i));
     }
 
-    pub(crate) fn tasks_in_current_column(&self) -> Vec<Task> {
+    pub fn tasks_in_current_column(&self) -> Vec<Task> {
         let status = match self.selected_column {
             0 => TaskStatus::ToDo,
             1 => TaskStatus::InProgress,
@@ -119,11 +119,11 @@ impl App {
             .collect()
     }
 
-    pub(crate) fn move_task_to_next_column(&mut self) {
+    pub fn move_task_to_next_column(&mut self) {
         self.move_task(1);
     }
 
-    pub(crate) fn move_task_to_prev_column(&mut self) {
+    pub fn move_task_to_prev_column(&mut self) {
         self.move_task(-1);
     }
 
@@ -156,7 +156,7 @@ impl App {
         }
     }
 
-    pub(crate) fn get_selected_task(&self) -> Option<Task> {
+    pub fn get_selected_task(&self) -> Option<Task> {
         self.selected_task[self.selected_column]
             .selected()
             .and_then(|selected_index| {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -137,6 +137,37 @@ async fn agent_execution_fails_without_tool() {
     assert!(matches!(result, ExecutionResult::Failure { .. }));
 }
 
+#[tokio::test]
+async fn agent_execution_fails_on_network_error_without_tool() {
+    std::env::set_var("GEMINI_API_KEY", "dummy");
+    std::env::set_var("https_proxy", "http://127.0.0.1:9");
+
+    let agent = Agent {
+        id: 1,
+        system_prompt: "General agent".into(),
+        tools: vec![],
+        model: "gpt-4o".into(),
+    };
+
+    let task = Task {
+        id: 1,
+        title: "Test".into(),
+        description: None,
+        status: TaskStatus::ToDo,
+        agent_id: Some(1),
+        comment: None,
+    };
+
+    let result = agent::execute_task(&agent, &task)
+        .await
+        .expect("execution failed");
+
+    assert!(matches!(result, ExecutionResult::Failure { .. }));
+
+    std::env::remove_var("GEMINI_API_KEY");
+    std::env::remove_var("https_proxy");
+}
+
 #[test]
 fn run_python_tool_executes_code() {
     let result = taskter::tools::execute_tool("run_python", &json!({ "code": "print(40 + 2)" }))

--- a/tests/tool_functions.rs
+++ b/tests/tool_functions.rs
@@ -333,3 +333,46 @@ fn taskter_tools_tool_lists_builtins() {
         std::env::remove_var("TASKTER_BIN");
     });
 }
+
+#[test]
+fn run_bash_requires_command_argument() {
+    with_temp_dir(|| {
+        let err = taskter::tools::execute_tool("run_bash", &json!({})).unwrap_err();
+        assert!(err.to_string().contains("command missing"));
+    });
+}
+
+#[test]
+fn run_bash_reports_command_failure() {
+    with_temp_dir(|| {
+        let err =
+            taskter::tools::execute_tool("run_bash", &json!({"command": "exit 1"})).unwrap_err();
+        assert!(err.to_string().contains("Command failed"));
+    });
+}
+
+#[test]
+fn run_python_requires_code_argument() {
+    with_temp_dir(|| {
+        let err = taskter::tools::execute_tool("run_python", &json!({})).unwrap_err();
+        assert!(err.to_string().contains("code missing"));
+    });
+}
+
+#[test]
+fn run_python_reports_execution_error() {
+    with_temp_dir(|| {
+        let err =
+            taskter::tools::execute_tool("run_python", &json!({"code": "import sys; sys.exit(1)"}))
+                .unwrap_err();
+        assert!(err.to_string().contains("Python execution failed"));
+    });
+}
+
+#[test]
+fn unknown_tool_returns_error() {
+    with_temp_dir(|| {
+        let err = taskter::tools::execute_tool("no_such_tool", &json!({})).unwrap_err();
+        assert!(err.to_string().contains("Unknown tool"));
+    });
+}

--- a/tests/tui_app.rs
+++ b/tests/tui_app.rs
@@ -1,0 +1,85 @@
+#![cfg(feature = "tui")]
+
+use taskter::agent::Agent;
+use taskter::store::{Board, Task, TaskStatus};
+use taskter::tui::app::App;
+
+mod common;
+use common::with_temp_dir;
+
+#[test]
+fn navigation_cycles_through_columns_and_tasks() {
+    with_temp_dir(|| {
+        let board = Board {
+            tasks: vec![
+                Task {
+                    id: 1,
+                    title: "A".into(),
+                    description: None,
+                    status: TaskStatus::ToDo,
+                    agent_id: None,
+                    comment: None,
+                },
+                Task {
+                    id: 2,
+                    title: "B".into(),
+                    description: None,
+                    status: TaskStatus::InProgress,
+                    agent_id: None,
+                    comment: None,
+                },
+                Task {
+                    id: 3,
+                    title: "C".into(),
+                    description: None,
+                    status: TaskStatus::Done,
+                    agent_id: None,
+                    comment: None,
+                },
+            ],
+        };
+        let mut app = App::new(board, Vec::<Agent>::new());
+        assert_eq!(app.selected_column, 0);
+        assert_eq!(app.get_selected_task().unwrap().id, 1);
+        app.next_column();
+        assert_eq!(app.selected_column, 1);
+        assert_eq!(app.get_selected_task().unwrap().id, 2);
+        app.next_column();
+        assert_eq!(app.selected_column, 2);
+        assert_eq!(app.get_selected_task().unwrap().id, 3);
+        app.next_column();
+        assert_eq!(app.selected_column, 0);
+    });
+}
+
+#[test]
+fn moving_task_updates_status() {
+    with_temp_dir(|| {
+        let board = Board {
+            tasks: vec![Task {
+                id: 1,
+                title: "T".into(),
+                description: None,
+                status: TaskStatus::ToDo,
+                agent_id: None,
+                comment: None,
+            }],
+        };
+        let mut app = App::new(board, Vec::<Agent>::new());
+        app.move_task_to_next_column();
+        assert_eq!(
+            app.board.lock().unwrap().tasks[0].status,
+            TaskStatus::InProgress
+        );
+        app.next_column();
+        app.move_task_to_next_column();
+        assert_eq!(app.board.lock().unwrap().tasks[0].status, TaskStatus::Done);
+        app.next_column();
+        app.move_task_to_prev_column();
+        app.prev_column();
+        assert_eq!(
+            app.board.lock().unwrap().tasks[0].status,
+            TaskStatus::InProgress
+        );
+    });
+}


### PR DESCRIPTION
## Summary
- expose `tui::App` so integration tests can drive it
- verify navigation and status updates through simulated TUI input
- check agent network errors and additional tool failures
- test error cases for `run_bash`, `run_python` and unknown tools

## Testing
- `cargo test`
- `cargo test --features tui`

------
https://chatgpt.com/codex/tasks/task_e_687ee9090ea4832080af307e94c5a3e1