### PR TITLE
Fix task movement selection bug

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -153,6 +153,16 @@ impl App {
                     _ => TaskStatus::Done,
                 };
             }
+
+            // Adjust selection if the task moved out of the current column
+            let tasks_left = self.tasks_in_current_column();
+            if tasks_left.is_empty() {
+                self.selected_task[self.selected_column].select(None);
+            } else if let Some(idx) = self.selected_task[self.selected_column].selected() {
+                if idx >= tasks_left.len() {
+                    self.selected_task[self.selected_column].select(Some(tasks_left.len() - 1));
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- fix stale selection when moving tasks across columns

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6880331a1224832084698d64bb7346dc