### PR TITLE
Add agent scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "shlex",
 ]
@@ -252,6 +252,28 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -348,6 +370,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "croner"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c344b0690c1ad1c7176fe18eb173e0c927008fdaaa256e40dfd43ddd149c0843"
+dependencies = [
+ "chrono",
+]
 
 [[package]]
 name = "crossterm"
@@ -485,7 +516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -982,9 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
+checksum = "435d80800b936787d62688c927b6490e887c7ef5ff9ce922c6c6050fca75eb9a"
 dependencies = [
  "darling",
  "indoc",
@@ -995,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
@@ -1194,7 +1225,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand",
+ "rand 0.9.2",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -1263,6 +1294,17 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "num-traits"
@@ -1371,6 +1413,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,6 +1432,44 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1495,12 +1584,21 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1510,8 +1608,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -1546,9 +1650,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -1657,15 +1761,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1782,9 +1886,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -1845,6 +1949,12 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -1986,6 +2096,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "chrono",
+ "chrono-tz",
  "clap",
  "crossterm",
  "lettre",
@@ -1999,6 +2110,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-cron-scheduler",
 ]
 
 [[package]]
@@ -2010,7 +2122,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 
@@ -2069,6 +2181,21 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-cron-scheduler"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c71ce8f810abc9fabebccc30302a952f9e89c6cf246fafaf170fef164063141"
+dependencies = [
+ "chrono",
+ "croner",
+ "num-derive",
+ "num-traits",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -2167,7 +2294,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2248,6 +2387,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ lettre = "0.11.17"
 chrono = { version = "0.4", features = ["serde"] }
 notify = "8.1"
 once_cell = "1.19"
+tokio-cron-scheduler = "0.14"
+chrono-tz = "0.8"
 [features]
 tui = []
 [dev-dependencies]

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,5 +5,6 @@
 - [CLI Usage](cli_usage.md)
 - [TUI Guide](tui_guide.md)
 - [Agent System](agent_system.md)
+- [Scheduling Agents](scheduling.md)
 - [Configuration](configuration.md)
 - [Contributing](contributing.md)

--- a/docs/src/scheduling.md
+++ b/docs/src/scheduling.md
@@ -1,0 +1,38 @@
+# Scheduling Agents
+
+Taskter can run agents automatically based on cron expressions. A scheduler daemon reads the agent configuration and executes the assigned tasks at the defined times.
+
+## Setting a Schedule
+
+Use the `agent schedule set` command to assign a cron expression to an agent. The expression is parsed in the `America/New_York` timezone.
+
+```bash
+# Run every minute
+taskter agent schedule set --id 1 --cron "0 * * * * *"
+```
+
+Pass `--once` to remove the schedule after the first run.
+
+## Listing and Removing
+
+List all scheduled agents with:
+
+```bash
+taskter agent schedule list
+```
+
+Remove a schedule:
+
+```bash
+taskter agent schedule remove --id 1
+```
+
+## Running the Scheduler
+
+Start the scheduler loop with:
+
+```bash
+taskter scheduler run
+```
+
+The scheduler will execute agents at the configured times and update tasks just as if `task execute` was run manually.

--- a/scripts/fix_lints.sh
+++ b/scripts/fix_lints.sh
@@ -4,6 +4,6 @@
 cargo fmt --all || exit 1
 
 # Automatically apply Clippy suggestions
-cargo clippy --all-targets --all-features --fix -Z unstable-options --allow-dirty --allow-staged || exit 1
+cargo clippy --all-targets --all-features --fix --allow-dirty --allow-staged || exit 1
 
 exit 0

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -265,6 +265,10 @@ pub struct Agent {
     pub system_prompt: String,
     pub tools: Vec<FunctionDeclaration>,
     pub model: String,
+    #[serde(default)]
+    pub schedule: Option<String>,
+    #[serde(default)]
+    pub repeat: bool,
 }
 
 /// Loads the list of agents from `.taskter/agents.json`.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -31,12 +31,17 @@ fn append_log(message: &str) -> anyhow::Result<()> {
 /// Executes a task with the given agent and records progress in `.taskter/logs.log`.
 ///
 /// Tools referenced by the agent may be invoked during execution.
-pub async fn execute_task(agent: &Agent, task: &Task) -> Result<ExecutionResult> {
+pub async fn execute_task(agent: &Agent, task: Option<&Task>) -> Result<ExecutionResult> {
     let client = Client::new();
-    if let Err(e) = append_log(&format!(
-        "Agent {} executing task {}: {}",
-        agent.id, task.id, task.title
-    )) {
+    let log_message = if let Some(task) = task {
+        format!(
+            "Agent {} executing task {}: {}",
+            agent.id, task.id, task.title
+        )
+    } else {
+        format!("Agent {} executing without a task", agent.id)
+    };
+    if let Err(e) = append_log(&log_message) {
         eprintln!("Failed to write log: {e}");
     }
     // Obtain the API key if it is available.  In a testing or offline environment the
@@ -87,13 +92,17 @@ pub async fn execute_task(agent: &Agent, task: &Task) -> Result<ExecutionResult>
 
     let api_key = api_key.unwrap();
 
-    let user_prompt = if let Some(description) = &task.description {
-        format!(
-            "Task Title: {}\nTask Description: {}",
-            task.title, description
-        )
+    let user_prompt = if let Some(task) = task {
+        if let Some(description) = &task.description {
+            format!(
+                "Task Title: {}\nTask Description: {}",
+                task.title, description
+            )
+        } else {
+            task.title.clone()
+        }
     } else {
-        task.title.clone()
+        String::new()
     };
 
     let mut history = vec![json!({

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,6 +41,11 @@ pub enum Commands {
         #[command(subcommand)]
         action: ToolCommands,
     },
+    /// Run the agent scheduler
+    Scheduler {
+        #[command(subcommand)]
+        action: SchedulerCommands,
+    },
     /// Opens the interactive board
     Board,
     /// Sets the project description
@@ -122,6 +127,37 @@ pub enum AgentCommands {
         #[arg(short, long, num_args = 1..)]
         tools: Vec<String>,
     },
+    /// Schedule operations for an agent
+    Schedule {
+        #[command(subcommand)]
+        action: ScheduleCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum ScheduleCommands {
+    /// Set a cron expression for an agent
+    Set {
+        #[arg(long)]
+        id: usize,
+        #[arg(long)]
+        cron: String,
+        #[arg(long)]
+        once: bool,
+    },
+    /// List scheduled agents
+    List,
+    /// Remove a schedule from an agent
+    Remove {
+        #[arg(long)]
+        id: usize,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum SchedulerCommands {
+    /// Run the scheduler loop
+    Run,
 }
 
 #[derive(Subcommand)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod agent;
 pub mod cli;
 pub mod config;
+pub mod scheduler;
 pub mod store;
 pub mod tools;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,7 @@ async fn main() -> anyhow::Result<()> {
                 if let Some(task) = board.tasks.iter_mut().find(|t| t.id == *task_id) {
                     if let Some(agent_id) = task.agent_id {
                         if let Some(agent) = agents.iter().find(|a| a.id == agent_id) {
-                            match agent::execute_task(agent, task).await {
+                            match agent::execute_task(agent, Some(task)).await {
                                 Ok(result) => match result {
                                     agent::ExecutionResult::Success { comment } => {
                                         task.status = store::TaskStatus::Done;

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -7,14 +7,14 @@ use tokio_cron_scheduler::{Job, JobScheduler};
 
 pub async fn run() -> anyhow::Result<()> {
     let agents = agent::load_agents()?;
-    let mut sched = JobScheduler::new().await?;
+    let sched = JobScheduler::new().await?;
 
     for ag in agents {
         if let Some(expr) = &ag.schedule {
             let job_agent = ag.clone();
             let cron_expr = expr.clone();
-            let mut job =
-                Job::new_async_tz(cron_expr, New_York, move |_id, mut l| {
+            let job =
+                Job::new_async_tz(cron_expr, New_York, move |_id, l| {
                     let a = job_agent.clone();
                     Box::pin(async move {
                         if let Ok(mut board) = store::load_board() {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -13,15 +13,24 @@ pub async fn run() -> anyhow::Result<()> {
         if let Some(expr) = &ag.schedule {
             let job_agent = ag.clone();
             let cron_expr = expr.clone();
-            let job =
-                Job::new_async_tz(cron_expr, New_York, move |_id, l| {
-                    let a = job_agent.clone();
-                    Box::pin(async move {
-                        if let Ok(mut board) = store::load_board() {
-                            for task in board.tasks.iter_mut().filter(|t| {
-                                t.agent_id == Some(a.id) && t.status != TaskStatus::Done
-                            }) {
-                                if let Ok(res) = agent::execute_task(&a, task).await {
+            let job = Job::new_async_tz(cron_expr, New_York, move |_id, l| {
+                let a = job_agent.clone();
+                Box::pin(async move {
+                    if let Ok(mut board) = store::load_board() {
+                        let tasks: Vec<usize> = board
+                            .tasks
+                            .iter()
+                            .filter(|t| t.agent_id == Some(a.id) && t.status != TaskStatus::Done)
+                            .map(|t| t.id)
+                            .collect();
+
+                        if tasks.is_empty() {
+                            let _ = agent::execute_task(&a, None).await;
+                        } else {
+                            for task_id in tasks {
+                                let task =
+                                    board.tasks.iter_mut().find(|t| t.id == task_id).unwrap();
+                                if let Ok(res) = agent::execute_task(&a, Some(task)).await {
                                     match res {
                                         ExecutionResult::Success { comment } => {
                                             task.status = TaskStatus::Done;
@@ -35,20 +44,21 @@ pub async fn run() -> anyhow::Result<()> {
                                     }
                                 }
                             }
-                            let _ = store::save_board(&board);
                         }
-                        if !a.repeat {
-                            let _ = l.remove(&_id).await;
-                            if let Ok(mut agents) = agent::load_agents() {
-                                if let Some(mut_a) = agents.iter_mut().find(|x| x.id == a.id) {
-                                    mut_a.schedule = None;
-                                    mut_a.repeat = false;
-                                    let _ = agent::save_agents(&agents);
-                                }
+                        let _ = store::save_board(&board);
+                    }
+                    if !a.repeat {
+                        let _ = l.remove(&_id).await;
+                        if let Ok(mut agents) = agent::load_agents() {
+                            if let Some(mut_a) = agents.iter_mut().find(|x| x.id == a.id) {
+                                mut_a.schedule = None;
+                                mut_a.repeat = false;
+                                let _ = agent::save_agents(&agents);
                             }
                         }
-                    })
-                })?;
+                    }
+                })
+            })?;
             sched.add(job).await?;
         }
     }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,0 +1,61 @@
+use crate::{agent, store};
+use agent::ExecutionResult;
+use chrono_tz::America::New_York;
+use std::time::Duration;
+use store::TaskStatus;
+use tokio_cron_scheduler::{Job, JobScheduler};
+
+pub async fn run() -> anyhow::Result<()> {
+    let agents = agent::load_agents()?;
+    let mut sched = JobScheduler::new().await?;
+
+    for ag in agents {
+        if let Some(expr) = &ag.schedule {
+            let job_agent = ag.clone();
+            let cron_expr = expr.clone();
+            let mut job =
+                Job::new_async_tz(cron_expr, New_York, move |_id, mut l| {
+                    let a = job_agent.clone();
+                    Box::pin(async move {
+                        if let Ok(mut board) = store::load_board() {
+                            for task in board.tasks.iter_mut().filter(|t| {
+                                t.agent_id == Some(a.id) && t.status != TaskStatus::Done
+                            }) {
+                                if let Ok(res) = agent::execute_task(&a, task).await {
+                                    match res {
+                                        ExecutionResult::Success { comment } => {
+                                            task.status = TaskStatus::Done;
+                                            task.comment = Some(comment);
+                                        }
+                                        ExecutionResult::Failure { comment } => {
+                                            task.status = TaskStatus::ToDo;
+                                            task.comment = Some(comment);
+                                            task.agent_id = None;
+                                        }
+                                    }
+                                }
+                            }
+                            let _ = store::save_board(&board);
+                        }
+                        if !a.repeat {
+                            let _ = l.remove(&_id).await;
+                            if let Ok(mut agents) = agent::load_agents() {
+                                if let Some(mut_a) = agents.iter_mut().find(|x| x.id == a.id) {
+                                    mut_a.schedule = None;
+                                    mut_a.repeat = false;
+                                    let _ = agent::save_agents(&agents);
+                                }
+                            }
+                        }
+                    })
+                })?;
+            sched.add(job).await?;
+        }
+    }
+
+    sched.start().await?;
+
+    loop {
+        tokio::time::sleep(Duration::from_secs(3600)).await;
+    }
+}

--- a/src/tui/handlers.rs
+++ b/src/tui/handlers.rs
@@ -215,9 +215,11 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                                         let task_clone = task.clone();
                                         let board_clone = Arc::clone(&app.board);
                                         tokio::spawn(async move {
-                                            let result =
-                                                agent::execute_task(&agent_clone, &task_clone)
-                                                    .await;
+                                            let result = agent::execute_task(
+                                                &agent_clone,
+                                                Some(&task_clone),
+                                            )
+                                            .await;
                                             let mut board = board_clone.lock().unwrap();
                                             if let Some(task) = board
                                                 .tasks

--- a/tests/cli_commands.rs
+++ b/tests/cli_commands.rs
@@ -80,7 +80,7 @@ fn add_agent_and_execute_task() {
                 "--tools",
                 "email",
                 "--model",
-                "gpt-4o",
+                "gemini-2.5-flash",
             ])
             .assert()
             .success();
@@ -118,7 +118,14 @@ fn list_and_delete_agents() {
         Command::cargo_bin("taskter")
             .unwrap()
             .args([
-                "agent", "add", "--prompt", "helper", "--tools", "email", "--model", "gpt-4o",
+                "agent",
+                "add",
+                "--prompt",
+                "helper",
+                "--tools",
+                "email",
+                "--model",
+                "gemini-2.5-flash",
             ])
             .assert()
             .success();
@@ -133,7 +140,7 @@ fn list_and_delete_agents() {
             .stdout
             .clone();
         let output = String::from_utf8(out).unwrap();
-        assert!(output.contains("1: helper (model: gpt-4o, tools: send_email)"));
+        assert!(output.contains("1: helper (model: gemini-2.5-flash, tools: send_email)"));
 
         // delete agent
         Command::cargo_bin("taskter")
@@ -163,7 +170,14 @@ fn update_agent_changes_configuration() {
         Command::cargo_bin("taskter")
             .unwrap()
             .args([
-                "agent", "add", "--prompt", "helper", "--tools", "email", "--model", "gpt-4o",
+                "agent",
+                "add",
+                "--prompt",
+                "helper",
+                "--tools",
+                "email",
+                "--model",
+                "gemini-2.5-flash",
             ])
             .assert()
             .success();
@@ -181,7 +195,7 @@ fn update_agent_changes_configuration() {
                 "--tools",
                 "create_task",
                 "--model",
-                "gpt-4o-small",
+                "gemini-2.5-flash",
             ])
             .assert()
             .success()
@@ -192,7 +206,7 @@ fn update_agent_changes_configuration() {
                 .unwrap();
         assert_eq!(agents[0]["system_prompt"], "new helper");
         assert_eq!(agents[0]["tools"][0]["name"], "create_task");
-        assert_eq!(agents[0]["model"], "gpt-4o-small");
+        assert_eq!(agents[0]["model"], "gemini-2.5-flash");
     });
 }
 
@@ -280,7 +294,14 @@ fn schedule_agent_updates_file() {
         Command::cargo_bin("taskter")
             .unwrap()
             .args([
-                "agent", "add", "--prompt", "helper", "--tools", "email", "--model", "gpt-4o",
+                "agent",
+                "add",
+                "--prompt",
+                "helper",
+                "--tools",
+                "email",
+                "--model",
+                "gemini-2.5-flash",
             ])
             .assert()
             .success();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -103,7 +103,7 @@ async fn agent_executes_email_task_successfully() {
     };
 
     // When
-    let result = agent::execute_task(&agent, &task)
+    let result = agent::execute_task(&agent, Some(&task))
         .await
         .expect("execution failed");
 
@@ -133,7 +133,7 @@ async fn agent_execution_fails_without_tool() {
     };
 
     // When
-    let result = agent::execute_task(&agent, &task)
+    let result = agent::execute_task(&agent, Some(&task))
         .await
         .expect("execution failed");
 
@@ -164,7 +164,7 @@ async fn agent_execution_fails_on_network_error_without_tool() {
         comment: None,
     };
 
-    let result = agent::execute_task(&agent, &task)
+    let result = agent::execute_task(&agent, Some(&task))
         .await
         .expect("execution failed");
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -88,7 +88,7 @@ async fn agent_executes_email_task_successfully() {
             description: Some("".into()),
             parameters: json!({}),
         }],
-        model: "gpt-4o".into(),
+        model: "gemini-2.5-flash".into(),
         schedule: None,
         repeat: false,
     };
@@ -118,7 +118,7 @@ async fn agent_execution_fails_without_tool() {
         id: 1,
         system_prompt: "General agent".into(),
         tools: vec![],
-        model: "gpt-4o".into(),
+        model: "gemini-2.5-flash".into(),
         schedule: None,
         repeat: false,
     };
@@ -150,7 +150,7 @@ async fn agent_execution_fails_on_network_error_without_tool() {
         id: 1,
         system_prompt: "General agent".into(),
         tools: vec![],
-        model: "gpt-4o".into(),
+        model: "gemini-2.5-flash".into(),
         schedule: None,
         repeat: false,
     };

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -151,6 +151,8 @@ async fn agent_execution_fails_on_network_error_without_tool() {
         system_prompt: "General agent".into(),
         tools: vec![],
         model: "gpt-4o".into(),
+        schedule: None,
+        repeat: false,
     };
 
     let task = Task {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -89,6 +89,8 @@ async fn agent_executes_email_task_successfully() {
             parameters: json!({}),
         }],
         model: "gpt-4o".into(),
+        schedule: None,
+        repeat: false,
     };
 
     let task = Task {
@@ -117,6 +119,8 @@ async fn agent_execution_fails_without_tool() {
         system_prompt: "General agent".into(),
         tools: vec![],
         model: "gpt-4o".into(),
+        schedule: None,
+        repeat: false,
     };
 
     let task = Task {

--- a/tests/tool_functions.rs
+++ b/tests/tool_functions.rs
@@ -283,7 +283,14 @@ fn taskter_agent_tool_lists_agents() {
         Command::cargo_bin("taskter")
             .unwrap()
             .args([
-                "agent", "add", "--prompt", "helper", "--tools", "run_bash", "--model", "gpt-4o",
+                "agent",
+                "add",
+                "--prompt",
+                "helper",
+                "--tools",
+                "run_bash",
+                "--model",
+                "gemini-2.5-flash",
             ])
             .assert()
             .success();

--- a/tests/tool_functions.rs
+++ b/tests/tool_functions.rs
@@ -51,6 +51,8 @@ fn assign_agent_assigns_task() {
             system_prompt: "p".into(),
             tools: vec![],
             model: "m".into(),
+            schedule: None,
+            repeat: false,
         };
         agent::save_agents(&[agent]).unwrap();
 
@@ -87,6 +89,8 @@ fn assign_agent_reports_missing_task() {
             system_prompt: "p".into(),
             tools: vec![],
             model: "m".into(),
+            schedule: None,
+            repeat: false,
         };
         agent::save_agents(&[agent]).unwrap();
         let msg = assign_agent::execute(&json!({"task_id":1,"agent_id":1})).unwrap();
@@ -152,6 +156,8 @@ fn list_agents_outputs_json() {
             system_prompt: "p".into(),
             tools: vec![],
             model: "m".into(),
+            schedule: None,
+            repeat: false,
         };
         agent::save_agents(&[agent.clone()]).unwrap();
         let out = list_agents::execute(&json!({})).unwrap();


### PR DESCRIPTION
## Summary
- add cron-based scheduling fields to Agent
- implement scheduler daemon
- extend CLI with scheduler commands
- document agent scheduling
- test schedule CLI operations

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687f910557a0832088ed65e674aa8b71