### PR TITLE
Allow updating agent model

### DIFF
--- a/docs/src/agent_system.md
+++ b/docs/src/agent_system.md
@@ -50,3 +50,13 @@ taskter task execute --task-id 1
 When a task is executed, the agent will attempt to perform the task. If successful, the task is marked as "Done". If it fails, the task is moved back to "To Do", unassigned, and a comment from the agent is added.
 
 In the interactive board (`taskter board`), tasks assigned to an agent will be marked with a `*`. You can view the assigned agent ID and any comments by selecting the task and pressing `Enter`.
+
+## Updating an Agent
+
+Use the `agent update` command to modify an existing agent's configuration:
+
+```bash
+taskter agent update --id 1 --prompt "New prompt" --tools "create_task" --model "gemini-pro"
+```
+
+All three options are required and the previous configuration is overwritten.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -310,11 +310,13 @@ pub fn update_agent(
     id: usize,
     prompt: String,
     tools: Vec<FunctionDeclaration>,
+    model: String,
 ) -> anyhow::Result<()> {
     let mut agents = load_agents()?;
     if let Some(agent) = agents.iter_mut().find(|a| a.id == id) {
         agent.system_prompt = prompt;
         agent.tools = tools;
+        agent.model = model;
         save_agents(&agents)?;
     }
     Ok(())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -121,6 +121,9 @@ pub enum AgentCommands {
         /// The new tools the agent can use
         #[arg(short, long, num_args = 1..)]
         tools: Vec<String>,
+        /// The new model for the agent
+        #[arg(short, long)]
+        model: String,
     },
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,7 +176,12 @@ async fn main() -> anyhow::Result<()> {
                 agent::delete_agent(*id)?;
                 println!("Agent {id} deleted.");
             }
-            AgentCommands::Update { id, prompt, tools } => {
+            AgentCommands::Update {
+                id,
+                prompt,
+                tools,
+                model,
+            } => {
                 let mut function_declarations = Vec::new();
                 for spec in tools {
                     let decl = if Path::new(spec).exists() {
@@ -191,7 +196,7 @@ async fn main() -> anyhow::Result<()> {
                     function_declarations.push(decl);
                 }
 
-                agent::update_agent(*id, prompt.clone(), function_declarations)?;
+                agent::update_agent(*id, prompt.clone(), function_declarations, model.clone())?;
                 println!("Agent {id} updated.");
             }
         },

--- a/tests/cli_commands.rs
+++ b/tests/cli_commands.rs
@@ -180,6 +180,8 @@ fn update_agent_changes_configuration() {
                 "new helper",
                 "--tools",
                 "create_task",
+                "--model",
+                "gpt-4o-small",
             ])
             .assert()
             .success()
@@ -190,6 +192,7 @@ fn update_agent_changes_configuration() {
                 .unwrap();
         assert_eq!(agents[0]["system_prompt"], "new helper");
         assert_eq!(agents[0]["tools"][0]["name"], "create_task");
+        assert_eq!(agents[0]["model"], "gpt-4o-small");
     });
 }
 


### PR DESCRIPTION
## Summary
- extend `agent update` command to accept a `--model` argument
- persist the new model value when updating agents
- document how to update an agent
- test updating the model

## Testing
- `./scripts/precommit.sh`

------
https://chatgpt.com/codex/tasks/task_e_688041a545488320aace26f453acfec4