### PR TITLE
Fix unique task IDs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ async fn main() -> anyhow::Result<()> {
             TaskCommands::Add { title, description } => {
                 let mut board = store::load_board()?;
                 let new_task = store::Task {
-                    id: board.tasks.len() + 1,
+                    id: board.next_task_id(),
                     title: title.clone(),
                     description: description.clone(),
                     status: store::TaskStatus::ToDo,

--- a/src/store.rs
+++ b/src/store.rs
@@ -28,6 +28,13 @@ pub struct Board {
     pub tasks: Vec<Task>,
 }
 
+impl Board {
+    /// Returns the next available unique task ID.
+    pub fn next_task_id(&self) -> usize {
+        self.tasks.iter().map(|t| t.id).max().unwrap_or(0) + 1
+    }
+}
+
 /// A measurable key result belonging to an [`Okr`].
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct KeyResult {

--- a/src/tools/create_task.rs
+++ b/src/tools/create_task.rs
@@ -24,7 +24,7 @@ pub fn execute(args: &Value) -> Result<String> {
         .map(String::from);
 
     let mut board = store::load_board()?;
-    let id = board.tasks.len() + 1;
+    let id = board.next_task_id();
     let task = Task {
         id,
         title: title.to_string(),

--- a/src/tui/handlers.rs
+++ b/src/tui/handlers.rs
@@ -306,7 +306,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                         }
                         KeyCode::Enter => {
                             if app.editing_description {
-                                let new_id = app.board.lock().unwrap().tasks.len() + 1;
+                                let new_id = app.board.lock().unwrap().next_task_id();
                                 let task = Task {
                                     id: new_id,
                                     title: app.new_task_title.clone(),

--- a/tests/agent_persistence.rs
+++ b/tests/agent_persistence.rs
@@ -23,6 +23,8 @@ fn save_agents_persists_to_disk() {
             system_prompt: "p".into(),
             tools: vec![],
             model: "m".into(),
+            schedule: None,
+            repeat: false,
         };
         agent::save_agents(&[agent.clone()]).expect("save failed");
         let stored: Vec<Agent> =
@@ -46,6 +48,8 @@ fn list_agents_returns_saved_agents() {
                 parameters: serde_json::json!({}),
             }],
             model: "m".into(),
+            schedule: None,
+            repeat: false,
         };
         agent::save_agents(&[agent.clone()]).unwrap();
         let listed = agent::list_agents().unwrap();
@@ -63,12 +67,16 @@ fn delete_agent_removes_entry() {
             system_prompt: "p1".into(),
             tools: vec![],
             model: "m".into(),
+            schedule: None,
+            repeat: false,
         };
         let a2 = Agent {
             id: 2,
             system_prompt: "p2".into(),
             tools: vec![],
             model: "m".into(),
+            schedule: None,
+            repeat: false,
         };
         agent::save_agents(&[a1.clone(), a2.clone()]).unwrap();
         agent::delete_agent(1).unwrap();


### PR DESCRIPTION
## Summary
- ensure new tasks get unique IDs
- update agent persistence tests for schedule and repeat fields
- apply `precommit` checks to format, lint, and test

## Testing
- `./scripts/precommit.sh`

------
https://chatgpt.com/codex/tasks/task_e_6881861ee1cc8320bbfb9f26b7f3d9aa