### PR TITLE
Add pedantic clippy to precommit

### DIFF
--- a/scripts/precommit.sh
+++ b/scripts/precommit.sh
@@ -4,7 +4,7 @@
 cargo fmt --all -- --check || exit 1
 
 # Lint code with clippy
-cargo clippy --all-targets --all-features -- -D warnings || exit 1
+cargo clippy --all-targets --all-features -- -D warnings -D clippy::pedantic || exit 1
 
 # Run tests
 cargo test || exit 1


### PR DESCRIPTION
## Summary
- enforce pedantic clippy checks in precommit script

## Testing
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings -D clippy::pedantic` *(fails)*


------
https://chatgpt.com/codex/tasks/task_e_6884cf3fd4e08320beef15640829fca9