### PR TITLE
Enable partial agent updates

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -321,15 +321,21 @@ pub fn delete_agent(id: usize) -> anyhow::Result<()> {
 /// Updates an existing agent in `.taskter/agents.json`.
 pub fn update_agent(
     id: usize,
-    prompt: String,
-    tools: Vec<FunctionDeclaration>,
-    model: String,
+    prompt: Option<String>,
+    tools: Option<Vec<FunctionDeclaration>>,
+    model: Option<String>,
 ) -> anyhow::Result<()> {
     let mut agents = load_agents()?;
     if let Some(agent) = agents.iter_mut().find(|a| a.id == id) {
-        agent.system_prompt = prompt;
-        agent.tools = tools;
-        agent.model = model;
+        if let Some(p) = prompt {
+            agent.system_prompt = p;
+        }
+        if let Some(t) = tools {
+            agent.tools = t;
+        }
+        if let Some(m) = model {
+            agent.model = m;
+        }
         save_agents(&agents)?;
     }
     Ok(())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -122,13 +122,13 @@ pub enum AgentCommands {
         id: usize,
         /// The new system prompt for the agent
         #[arg(short, long)]
-        prompt: String,
+        prompt: Option<String>,
         /// The new tools the agent can use
         #[arg(short, long, num_args = 1..)]
-        tools: Vec<String>,
+        tools: Option<Vec<String>>,
         /// The new model for the agent
         #[arg(short, long)]
-        model: String,
+        model: Option<String>,
     },
     /// Schedule operations for an agent
     Schedule {

--- a/tests/cli_commands.rs
+++ b/tests/cli_commands.rs
@@ -158,7 +158,7 @@ fn list_and_delete_agents() {
 }
 
 #[test]
-fn update_agent_changes_configuration() {
+fn update_agent_allows_partial_changes() {
     with_temp_dir(|| {
         Command::cargo_bin("taskter")
             .unwrap()
@@ -182,21 +182,10 @@ fn update_agent_changes_configuration() {
             .assert()
             .success();
 
-        // update the agent
+        // update only the tools of the agent
         Command::cargo_bin("taskter")
             .unwrap()
-            .args([
-                "agent",
-                "update",
-                "--id",
-                "1",
-                "--prompt",
-                "new helper",
-                "--tools",
-                "taskter_task",
-                "--model",
-                "gemini-2.5-flash",
-            ])
+            .args(["agent", "update", "--id", "1", "--tools", "taskter_task"])
             .assert()
             .success()
             .stdout(predicate::str::contains("Agent 1 updated."));
@@ -204,7 +193,8 @@ fn update_agent_changes_configuration() {
         let agents: Vec<Value> =
             serde_json::from_str(&fs::read_to_string(taskter::config::AGENTS_FILE).unwrap())
                 .unwrap();
-        assert_eq!(agents[0]["system_prompt"], "new helper");
+        // only tools should have changed
+        assert_eq!(agents[0]["system_prompt"], "helper");
         assert_eq!(agents[0]["tools"][0]["name"], "taskter_task");
         assert_eq!(agents[0]["model"], "gemini-2.5-flash");
     });


### PR DESCRIPTION
## Summary
- make prompt, model and tools optional for `agent update`
- support optional fields in CLI and update function
- allow updating a single attribute
- test partial update workflow

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6884dc0e6eac8320be0d5a35129c242c