### PR TITLE
Add project_files tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2164,6 +2164,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-cron-scheduler",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ notify = "8.1"
 once_cell = "1.19"
 tokio-cron-scheduler = "0.14"
 chrono-tz = "0.8"
+walkdir = "2"
 [features]
 default = ["tui"]
 tui = []

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Taskter now supports LLM-based agents that can be assigned to tasks. These agent
   the name of a built-in tool. Built-ins live under the `tools/` directory of
   the repository. For example `email` resolves to `tools/send_email.json`.
   Other built-ins include `taskter_task`, `taskter_agent`, `taskter_okrs`,
-  `taskter_tools`, `get_description`, `run_bash`, `run_python`,
+  `taskter_tools`, `get_description`, `run_bash`, `run_python`, `file_ops`,
   `send_email`, and `web_search`.
   The `taskter_*` tools wrap the corresponding CLI subcommands. Example:
   ```json

--- a/docs/src/agent_system.md
+++ b/docs/src/agent_system.md
@@ -23,6 +23,7 @@ Available built-in tools:
 - `send_email`
 - `web_search`
 - `project_files`
+- `file_ops`
 
 You can display this list at any time with:
 

--- a/docs/src/agent_system.md
+++ b/docs/src/agent_system.md
@@ -22,6 +22,7 @@ Available built-in tools:
 - `run_python`
 - `send_email`
 - `web_search`
+- `project_files`
 
 You can display this list at any time with:
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -7,6 +7,7 @@ use crate::agent::FunctionDeclaration;
 
 pub mod email;
 pub mod get_description;
+pub mod project_files;
 pub mod run_bash;
 pub mod run_python;
 pub mod taskter_agent;
@@ -28,6 +29,7 @@ pub static BUILTIN_TOOLS: Lazy<HashMap<&'static str, Tool>> = Lazy::new(|| {
     get_description::register(&mut m);
     run_bash::register(&mut m);
     run_python::register(&mut m);
+    project_files::register(&mut m);
     web_search::register(&mut m);
     taskter_task::register(&mut m);
     taskter_agent::register(&mut m);

--- a/src/tools/project_files.rs
+++ b/src/tools/project_files.rs
@@ -1,0 +1,81 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::fs;
+
+use crate::agent::FunctionDeclaration;
+use crate::tools::Tool;
+
+const DECL_JSON: &str = include_str!("../../tools/project_files.json");
+
+/// Returns the function declaration for this tool.
+pub fn declaration() -> FunctionDeclaration {
+    serde_json::from_str(DECL_JSON).expect("invalid project_files.json")
+}
+
+/// Executes file operations in the project directory.
+pub fn execute(args: &Value) -> Result<String> {
+    let action = args["action"]
+        .as_str()
+        .ok_or_else(|| anyhow!("action missing"))?;
+    match action {
+        "create" => {
+            let path = args["path"]
+                .as_str()
+                .ok_or_else(|| anyhow!("path missing"))?;
+            let content = args["content"].as_str().unwrap_or_default();
+            fs::write(path, content)?;
+            Ok(format!("Created {path}"))
+        }
+        "read" => {
+            let path = args["path"]
+                .as_str()
+                .ok_or_else(|| anyhow!("path missing"))?;
+            let content = fs::read_to_string(path)?;
+            Ok(content)
+        }
+        "update" => {
+            let path = args["path"]
+                .as_str()
+                .ok_or_else(|| anyhow!("path missing"))?;
+            let content = args["content"]
+                .as_str()
+                .ok_or_else(|| anyhow!("content missing"))?;
+            fs::write(path, content)?;
+            Ok(format!("Updated {path}"))
+        }
+        "search" => {
+            let query = args["query"]
+                .as_str()
+                .ok_or_else(|| anyhow!("query missing"))?;
+            let mut matches = Vec::new();
+            for entry in walkdir::WalkDir::new(".") {
+                let entry = entry?;
+                if entry.file_type().is_file() {
+                    if let Ok(contents) = fs::read_to_string(entry.path()) {
+                        if contents.contains(query) {
+                            matches.push(entry.path().display().to_string());
+                        }
+                    }
+                }
+            }
+            if matches.is_empty() {
+                Ok("No matches found".to_string())
+            } else {
+                Ok(matches.join("\n"))
+            }
+        }
+        _ => Err(anyhow!("unknown action")),
+    }
+}
+
+/// Registers the tool in the provided map.
+pub fn register(map: &mut HashMap<&'static str, Tool>) {
+    map.insert(
+        "project_files",
+        Tool {
+            declaration: declaration(),
+            execute,
+        },
+    );
+}

--- a/src/tools/project_files.rs
+++ b/src/tools/project_files.rs
@@ -71,10 +71,19 @@ pub fn execute(args: &Value) -> Result<String> {
 
 /// Registers the tool in the provided map.
 pub fn register(map: &mut HashMap<&'static str, Tool>) {
+    // Register under both "project_files" and alias "file_ops"
+    let decl = declaration();
     map.insert(
         "project_files",
         Tool {
-            declaration: declaration(),
+            declaration: decl.clone(),
+            execute,
+        },
+    );
+    map.insert(
+        "file_ops",
+        Tool {
+            declaration: decl,
             execute,
         },
     );

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -77,7 +77,7 @@ fn comment_roundtrip_persists_changes() {
     });
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn agent_executes_email_task_successfully() {
     // Given
     let agent = Agent {
@@ -111,7 +111,7 @@ async fn agent_executes_email_task_successfully() {
     assert!(matches!(result, ExecutionResult::Success { .. }));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn agent_execution_fails_without_tool() {
     // Given
     let agent = Agent {
@@ -141,7 +141,7 @@ async fn agent_execution_fails_without_tool() {
     assert!(matches!(result, ExecutionResult::Failure { .. }));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn agent_execution_fails_on_network_error_without_tool() {
     std::env::set_var("GEMINI_API_KEY", "dummy");
     std::env::set_var("https_proxy", "http://127.0.0.1:9");

--- a/tools/project_files.json
+++ b/tools/project_files.json
@@ -1,0 +1,14 @@
+{
+  "name": "project_files",
+  "description": "Create, read, search, and update text files within the project directory.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "action": { "type": "string", "description": "Operation to perform: create, read, search, or update" },
+      "path": { "type": "string", "description": "Relative file path for create, read, or update actions" },
+      "content": { "type": "string", "description": "File content for create or update" },
+      "query": { "type": "string", "description": "Search string when action is search" }
+    },
+    "required": ["action"]
+  }
+}


### PR DESCRIPTION
## Summary
- create new `project_files` tool for managing text files
- register the tool and document it
- depend on `walkdir` crate

## Testing
- `./scripts/precommit.sh`

------
https://chatgpt.com/codex/tasks/task_e_6886cc5c23e8832090e511690dd1c13a