### PR TITLE
Group task list by status

### DIFF
--- a/src/commands/task.rs
+++ b/src/commands/task.rs
@@ -19,14 +19,52 @@ pub async fn handle(action: &TaskCommands) -> anyhow::Result<()> {
         }
         TaskCommands::List => {
             let board = store::load_board()?;
+            let mut todo = Vec::new();
+            let mut in_progress = Vec::new();
+            let mut done = Vec::new();
+
             for task in board.tasks {
-                println!(
-                    "[{}] {} - {:?} - {:?}",
-                    task.id,
-                    task.title,
-                    task.status,
-                    task.description.unwrap_or_default()
-                );
+                match task.status {
+                    store::TaskStatus::ToDo => todo.push(task),
+                    store::TaskStatus::InProgress => in_progress.push(task),
+                    store::TaskStatus::Done => done.push(task),
+                }
+            }
+
+            if !todo.is_empty() {
+                println!("ToDo:");
+                for task in todo {
+                    println!(
+                        "  [{}] {} - {}",
+                        task.id,
+                        task.title,
+                        task.description.unwrap_or_default()
+                    );
+                }
+            }
+
+            if !in_progress.is_empty() {
+                println!("InProgress:");
+                for task in in_progress {
+                    println!(
+                        "  [{}] {} - {}",
+                        task.id,
+                        task.title,
+                        task.description.unwrap_or_default()
+                    );
+                }
+            }
+
+            if !done.is_empty() {
+                println!("Done:");
+                for task in done {
+                    println!(
+                        "  [{}] {} - {}",
+                        task.id,
+                        task.title,
+                        task.description.unwrap_or_default()
+                    );
+                }
             }
         }
         TaskCommands::Complete { id } => {

--- a/src/commands/task.rs
+++ b/src/commands/task.rs
@@ -31,39 +31,37 @@ pub async fn handle(action: &TaskCommands) -> anyhow::Result<()> {
                 }
             }
 
+            fn print_task(task: &store::Task) {
+                match &task.description {
+                    Some(desc) if !desc.is_empty() => {
+                        println!("  [{}] {} - {}", task.id, task.title, desc);
+                    }
+                    _ => {
+                        println!("  [{}] {}", task.id, task.title);
+                    }
+                }
+            }
+
             if !todo.is_empty() {
                 println!("ToDo:");
-                for task in todo {
-                    println!(
-                        "  [{}] {} - {}",
-                        task.id,
-                        task.title,
-                        task.description.unwrap_or_default()
-                    );
+                for task in &todo {
+                    print_task(task);
                 }
+                println!();
             }
 
             if !in_progress.is_empty() {
                 println!("InProgress:");
-                for task in in_progress {
-                    println!(
-                        "  [{}] {} - {}",
-                        task.id,
-                        task.title,
-                        task.description.unwrap_or_default()
-                    );
+                for task in &in_progress {
+                    print_task(task);
                 }
+                println!();
             }
 
             if !done.is_empty() {
                 println!("Done:");
-                for task in done {
-                    println!(
-                        "  [{}] {} - {}",
-                        task.id,
-                        task.title,
-                        task.description.unwrap_or_default()
-                    );
+                for task in &done {
+                    print_task(task);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- group `task list` output by ToDo, InProgress and Done

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6886d1c9a0b883209c1e6c0c49c11743