### PR TITLE
Handle malformed API responses

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -213,7 +213,24 @@ pub async fn execute_task(agent: &Agent, task: Option<&Task>) -> Result<Executio
         let part = &candidate["content"]["parts"][0];
 
         if let Some(function_call) = part.get("functionCall") {
-            let tool_name = function_call["name"].as_str().unwrap();
+            let tool_name = match function_call
+                .get("name")
+                .and_then(Value::as_str)
+                .ok_or_else(|| ExecutionResult::Failure {
+                    comment: "Malformed API response: missing field `name`".to_string(),
+                }) {
+                Ok(name) => name,
+                Err(failure) => {
+                    if let ExecutionResult::Failure { comment } = &failure {
+                        if let Err(e) =
+                            append_log(&format!("Agent {} failed: {}", agent.id, comment))
+                        {
+                            eprintln!("Failed to write log: {e}");
+                        }
+                    }
+                    return Ok(failure);
+                }
+            };
             let args = &function_call["args"];
             if let Err(e) = append_log(&format!(
                 "Agent {} calling tool {} with args {}",
@@ -235,8 +252,24 @@ pub async fn execute_task(agent: &Agent, task: Option<&Task>) -> Result<Executio
                 "role": "tool",
                 "parts": [{"functionResponse": {"name": tool_name, "response": {"content": tool_response}}}]
             }));
-        } else if let Some(text) = part.get("text") {
-            let comment = text.as_str().unwrap().to_string();
+        } else if part.get("text").is_some() {
+            let comment = match part.get("text").and_then(Value::as_str).ok_or_else(|| {
+                ExecutionResult::Failure {
+                    comment: "Malformed API response: missing field `text`".to_string(),
+                }
+            }) {
+                Ok(text) => text.to_string(),
+                Err(failure) => {
+                    if let ExecutionResult::Failure { comment } = &failure {
+                        if let Err(e) =
+                            append_log(&format!("Agent {} failed: {}", agent.id, comment))
+                        {
+                            eprintln!("Failed to write log: {e}");
+                        }
+                    }
+                    return Ok(failure);
+                }
+            };
             if let Err(e) = append_log(&format!(
                 "Agent {} finished successfully: {}",
                 agent.id, comment

--- a/tests/malformed_response.rs
+++ b/tests/malformed_response.rs
@@ -1,0 +1,26 @@
+use serde_json::json;
+use taskter::agent::ExecutionResult;
+
+#[test]
+fn missing_tool_name_returns_failure() {
+    let function_call = json!({"args": {}});
+    let result = function_call
+        .get("name")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| ExecutionResult::Failure {
+            comment: "Malformed API response: missing field `name`".to_string(),
+        });
+    assert!(matches!(result, Err(ExecutionResult::Failure { .. })));
+}
+
+#[test]
+fn non_string_text_returns_failure() {
+    let part = json!({"text": 123});
+    let result = part
+        .get("text")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| ExecutionResult::Failure {
+            comment: "Malformed API response: missing field `text`".to_string(),
+        });
+    assert!(matches!(result, Err(ExecutionResult::Failure { .. })));
+}


### PR DESCRIPTION
## Summary
- avoid panicking when the Gemini API omits `name` or `text`
- ensure failure is returned on malformed responses
- test the new extraction logic

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6886d246efd88320b392931661af6ea1