### PR TITLE
Fix unique task ID generation

### DIFF
--- a/src/commands/task.rs
+++ b/src/commands/task.rs
@@ -6,7 +6,7 @@ pub async fn handle(action: &TaskCommands) -> anyhow::Result<()> {
         TaskCommands::Add { title, description } => {
             let mut board = store::load_board()?;
             let new_task = store::Task {
-                id: board.tasks.len() + 1,
+                id: board.next_task_id(),
                 title: title.clone(),
                 description: description.clone(),
                 status: store::TaskStatus::ToDo,

--- a/src/store.rs
+++ b/src/store.rs
@@ -28,6 +28,13 @@ pub struct Board {
     pub tasks: Vec<Task>,
 }
 
+impl Board {
+    /// Calculates the next available task id.
+    pub fn next_task_id(&self) -> usize {
+        self.tasks.iter().map(|t| t.id).max().unwrap_or(0) + 1
+    }
+}
+
 /// A measurable key result belonging to an [`Okr`].
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct KeyResult {

--- a/src/tui/handlers.rs
+++ b/src/tui/handlers.rs
@@ -306,7 +306,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                         }
                         KeyCode::Enter => {
                             if app.editing_description {
-                                let new_id = app.board.lock().unwrap().tasks.len() + 1;
+                                let new_id = app.board.lock().unwrap().next_task_id();
                                 let task = Task {
                                     id: new_id,
                                     title: app.new_task_title.clone(),


### PR DESCRIPTION
## Summary
- ensure tasks receive a unique ID by computing the max existing id
- update CLI and TUI code to use the new `Board::next_task_id`

## Testing
- `./scripts/precommit.sh`

------
https://chatgpt.com/codex/tasks/task_e_6886ce14097c832084fc15d337ec199b