### PR TITLE
Allow updating specific agent fields

### DIFF
--- a/docs/src/agent_system.md
+++ b/docs/src/agent_system.md
@@ -54,7 +54,8 @@ In the interactive board (`taskter board`), tasks assigned to an agent will be m
 Use the `agent update` command to modify an existing agent's configuration:
 
 ```bash
-taskter agent update --id 1 --prompt "New prompt" --tools "taskter_task" --model "gemini-pro"
+taskter agent update --id 1 --prompt "New prompt" --model "gemini-pro"
 ```
 
-All three options are required and the previous configuration is overwritten.
+You can provide any combination of `--prompt`, `--tools`, and `--model`. Only the
+specified fields are changed and other settings remain intact.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -321,15 +321,21 @@ pub fn delete_agent(id: usize) -> anyhow::Result<()> {
 /// Updates an existing agent in `.taskter/agents.json`.
 pub fn update_agent(
     id: usize,
-    prompt: String,
-    tools: Vec<FunctionDeclaration>,
-    model: String,
+    prompt: Option<String>,
+    tools: Option<Vec<FunctionDeclaration>>,
+    model: Option<String>,
 ) -> anyhow::Result<()> {
     let mut agents = load_agents()?;
     if let Some(agent) = agents.iter_mut().find(|a| a.id == id) {
-        agent.system_prompt = prompt;
-        agent.tools = tools;
-        agent.model = model;
+        if let Some(p) = prompt {
+            agent.system_prompt = p;
+        }
+        if let Some(t) = tools {
+            agent.tools = t;
+        }
+        if let Some(m) = model {
+            agent.model = m;
+        }
         save_agents(&agents)?;
     }
     Ok(())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -122,13 +122,13 @@ pub enum AgentCommands {
         id: usize,
         /// The new system prompt for the agent
         #[arg(short, long)]
-        prompt: String,
+        prompt: Option<String>,
         /// The new tools the agent can use
         #[arg(short, long, num_args = 1..)]
-        tools: Vec<String>,
+        tools: Option<Vec<String>>,
         /// The new model for the agent
         #[arg(short, long)]
-        model: String,
+        model: Option<String>,
     },
     /// Schedule operations for an agent
     Schedule {

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -22,6 +22,16 @@ pub fn parse_tool_specs(specs: &[String]) -> anyhow::Result<Vec<FunctionDeclarat
     Ok(function_declarations)
 }
 
+pub fn parse_optional_tool_specs(
+    specs: &Option<Vec<String>>,
+) -> anyhow::Result<Option<Vec<FunctionDeclaration>>> {
+    if let Some(list) = specs {
+        Ok(Some(parse_tool_specs(list)?))
+    } else {
+        Ok(None)
+    }
+}
+
 pub async fn handle(action: &AgentCommands) -> anyhow::Result<()> {
     match action {
         AgentCommands::Add {
@@ -68,7 +78,7 @@ pub async fn handle(action: &AgentCommands) -> anyhow::Result<()> {
             tools,
             model,
         } => {
-            let function_declarations = parse_tool_specs(tools)?;
+            let function_declarations = parse_optional_tool_specs(tools)?;
             agent_model::update_agent(*id, prompt.clone(), function_declarations, model.clone())?;
             println!("Agent {id} updated.");
         }

--- a/tests/agent_persistence.rs
+++ b/tests/agent_persistence.rs
@@ -85,3 +85,23 @@ fn delete_agent_removes_entry() {
         assert_eq!(remaining[0].id, a2.id);
     });
 }
+
+#[test]
+fn update_agent_partial_update() {
+    with_temp_dir(|| {
+        let agent = Agent {
+            id: 1,
+            system_prompt: "p".into(),
+            tools: vec![],
+            model: "m1".into(),
+            schedule: None,
+            repeat: false,
+        };
+        agent::save_agents(&[agent.clone()]).unwrap();
+        // update only model
+        agent::update_agent(1, None, None, Some("m2".into())).unwrap();
+        let updated = agent::load_agents().unwrap();
+        assert_eq!(updated[0].model, "m2");
+        assert_eq!(updated[0].system_prompt, "p");
+    });
+}


### PR DESCRIPTION
## Summary
- make `agent update` CLI arguments optional
- parse optional tool specs for updates
- support partial updates in `update_agent`
- document optional update arguments
- test partial update capability

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6886ce5312fc8320ba63bfca77db4ec4