### PR TITLE
Add async runtime for TUI

### DIFF
--- a/src/commands/board.rs
+++ b/src/commands/board.rs
@@ -1,10 +1,13 @@
 #[cfg(feature = "tui")]
 use crate::tui;
+#[cfg(feature = "tui")]
+use tokio::runtime::Runtime;
 
 pub fn run() -> anyhow::Result<()> {
     #[cfg(feature = "tui")]
     {
-        return tui::run_tui();
+        let rt = Runtime::new()?;
+        return rt.block_on(tui::run_tui());
     }
     #[allow(unreachable_code)]
     Ok(())


### PR DESCRIPTION
## Summary
- convert TUI runner and event loop to async functions
- drive the board command with a Tokio runtime
- await `agent::execute_task` directly when assigning an agent

## Testing
- `cargo build --features tui`

------
https://chatgpt.com/codex/tasks/task_e_68897d0c16bc8320be6fba29fd11ca97