### PR TITLE
Add must_use annotations

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -12,6 +12,7 @@ use std::io::Write;
 use crate::config;
 
 /// Result of running an [`Agent`] on a [`Task`].
+#[must_use]
 #[derive(Debug, PartialEq)]
 pub enum ExecutionResult {
     Success { comment: String },
@@ -31,6 +32,7 @@ fn append_log(message: &str) -> anyhow::Result<()> {
 /// Executes a task with the given agent and records progress in `.taskter/logs.log`.
 ///
 /// Tools referenced by the agent may be invoked during execution.
+#[must_use = "Handle execution result to update task status"]
 pub async fn execute_task(agent: &Agent, task: Option<&Task>) -> Result<ExecutionResult> {
     let client = Client::new();
     let log_message = if let Some(task) = task {

--- a/src/tools/email.rs
+++ b/src/tools/email.rs
@@ -20,6 +20,7 @@ struct EmailConfig {
 const DECL_JSON: &str = include_str!("../../tools/send_email.json");
 
 /// Returns the function declaration for this tool.
+#[must_use]
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid send_email.json")
 }

--- a/src/tools/get_description.rs
+++ b/src/tools/get_description.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 const DECL_JSON: &str = include_str!("../../tools/get_description.json");
 
 /// Returns the function declaration for this tool.
+#[must_use]
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid get_description.json")
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -37,6 +37,7 @@ pub static BUILTIN_TOOLS: Lazy<HashMap<&'static str, Tool>> = Lazy::new(|| {
 });
 
 /// Returns the names of all built-in tools.
+#[must_use]
 pub fn builtin_names() -> Vec<&'static str> {
     let mut names: Vec<&'static str> = BUILTIN_TOOLS.keys().copied().collect();
     names.sort();
@@ -44,6 +45,7 @@ pub fn builtin_names() -> Vec<&'static str> {
 }
 
 /// Retrieves the declaration for a built-in tool by name.
+#[must_use]
 pub fn builtin_declaration(name: &str) -> Option<FunctionDeclaration> {
     BUILTIN_TOOLS.get(name).map(|t| t.declaration.clone())
 }

--- a/src/tools/run_bash.rs
+++ b/src/tools/run_bash.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 const DECL_JSON: &str = include_str!("../../tools/run_bash.json");
 
 /// Returns the function declaration for this tool.
+#[must_use]
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid run_bash.json")
 }

--- a/src/tools/run_python.rs
+++ b/src/tools/run_python.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 const DECL_JSON: &str = include_str!("../../tools/run_python.json");
 
 /// Returns the function declaration for this tool.
+#[must_use]
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid run_python.json")
 }

--- a/src/tools/taskter_agent.rs
+++ b/src/tools/taskter_agent.rs
@@ -15,6 +15,7 @@ fn taskter_bin() -> std::path::PathBuf {
         .unwrap_or_else(|_| "taskter".into())
 }
 
+#[must_use]
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid taskter_agent.json")
 }

--- a/src/tools/taskter_okrs.rs
+++ b/src/tools/taskter_okrs.rs
@@ -15,6 +15,7 @@ fn taskter_bin() -> std::path::PathBuf {
         .unwrap_or_else(|_| "taskter".into())
 }
 
+#[must_use]
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid taskter_okrs.json")
 }

--- a/src/tools/taskter_task.rs
+++ b/src/tools/taskter_task.rs
@@ -15,6 +15,7 @@ fn taskter_bin() -> std::path::PathBuf {
         .unwrap_or_else(|_| "taskter".into())
 }
 
+#[must_use]
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid taskter_task.json")
 }

--- a/src/tools/taskter_tools.rs
+++ b/src/tools/taskter_tools.rs
@@ -15,6 +15,7 @@ fn taskter_bin() -> std::path::PathBuf {
         .unwrap_or_else(|_| "taskter".into())
 }
 
+#[must_use]
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid taskter_tools.json")
 }

--- a/src/tools/web_search.rs
+++ b/src/tools/web_search.rs
@@ -7,6 +7,7 @@ use crate::tools::Tool;
 
 const DECL_JSON: &str = include_str!("../../tools/web_search.json");
 
+#[must_use]
 pub fn declaration() -> FunctionDeclaration {
     serde_json::from_str(DECL_JSON).expect("invalid web_search.json")
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -103,6 +103,7 @@ impl App {
         self.selected_task[self.selected_column].select(Some(i));
     }
 
+    #[must_use]
     pub fn tasks_in_current_column(&self) -> Vec<Task> {
         let status = match self.selected_column {
             0 => TaskStatus::ToDo,
@@ -166,6 +167,7 @@ impl App {
         }
     }
 
+    #[must_use]
     pub fn get_selected_task(&self) -> Option<Task> {
         self.selected_task[self.selected_column]
             .selected()


### PR DESCRIPTION
## Summary
- annotate `ExecutionResult` and essential methods with `#[must_use]`
- apply the attribute to builtin tool helpers in `tools`
- add more annotations in the TUI

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688564d568208320993a7afc97284a29