### PR TITLE
Refactor agent helpers and improve parsing

### DIFF
--- a/tests/agent_persistence.rs
+++ b/tests/agent_persistence.rs
@@ -23,6 +23,8 @@ fn save_agents_persists_to_disk() {
             system_prompt: "p".into(),
             tools: vec![],
             model: "m".into(),
+            schedule: None,
+            repeat: false,
         };
         agent::save_agents(&[agent.clone()]).expect("save failed");
         let stored: Vec<Agent> =
@@ -46,6 +48,8 @@ fn list_agents_returns_saved_agents() {
                 parameters: serde_json::json!({}),
             }],
             model: "m".into(),
+            schedule: None,
+            repeat: false,
         };
         agent::save_agents(&[agent.clone()]).unwrap();
         let listed = agent::list_agents().unwrap();
@@ -63,12 +67,16 @@ fn delete_agent_removes_entry() {
             system_prompt: "p1".into(),
             tools: vec![],
             model: "m".into(),
+            schedule: None,
+            repeat: false,
         };
         let a2 = Agent {
             id: 2,
             system_prompt: "p2".into(),
             tools: vec![],
             model: "m".into(),
+            schedule: None,
+            repeat: false,
         };
         agent::save_agents(&[a1.clone(), a2.clone()]).unwrap();
         agent::delete_agent(1).unwrap();


### PR DESCRIPTION
## Summary
- refactor `agent.rs` by splitting request/response helpers
- support offline fallback via dedicated function
- return errors with `anyhow::Context` instead of `unwrap`
- document behaviour of new helpers
- update tests for new `Agent` fields

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688197d1493483209b39b8aaf38b7014