### PR TITLE
Add log location note to docs

### DIFF
--- a/docs/src/cli_usage.md
+++ b/docs/src/cli_usage.md
@@ -16,6 +16,9 @@ taskter init
 
 This will create a `.taskter` directory to store all your tasks, agents, and project data.
 
+All operation logs are written to `.taskter/logs.log`. Inspect this file directly
+or run `taskter logs list` to view the history.
+
 ### 2. Create an agent
 
 Next, create an agent to help you with your tasks. For this example, we'll create a simple agent that can run bash commands:


### PR DESCRIPTION
## Summary
- mention `.taskter/logs.log` in CLI usage docs
- explain how to inspect log entries

## Testing
- `./scripts/precommit.sh`

------
https://chatgpt.com/codex/tasks/task_e_68897f95bffc8320b39bdf9bca9acd89