### PR TITLE
Add docs for .taskter files

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ taskter init
 ```
 
 This will create a `.taskter` directory to store all your tasks, agents, and project data.
+See the [Data Files](https://tomatyss.github.io/taskter/data_files.html) chapter for a detailed description of these files.
 
 ### 2. Create an agent
 
@@ -175,6 +176,7 @@ taskter init
 ```
 
 This will create a `.taskter` directory with the necessary files.
+See the [Data Files](https://tomatyss.github.io/taskter/data_files.html) chapter for details.
 
 ### Interactive Board
 
@@ -311,7 +313,10 @@ In the interactive board (`taskter board`), tasks assigned to an agent will be m
 
 Agent email tools read credentials from `.taskter/email_config.json`. Place this
 file inside the board directory (next to `board.json` and `agents.json`). All
-agents share the same configuration. The currently recognised keys are:
+agents share the same configuration. See the
+[Data Files](https://tomatyss.github.io/taskter/data_files.html) chapter for an
+overview of every file created during initialization. The currently recognised
+keys are:
 
 ```json
 {

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -6,5 +6,6 @@
 - [TUI Guide](tui_guide.md)
 - [Agent System](agent_system.md)
 - [Scheduling Agents](scheduling.md)
+- [Data Files](data_files.md)
 - [Configuration](configuration.md)
 - [Contributing](contributing.md)

--- a/docs/src/data_files.md
+++ b/docs/src/data_files.md
@@ -1,0 +1,28 @@
+# Data Files
+
+Taskter keeps all project state inside a `.taskter` directory. This folder is created when you run `taskter init`.
+The following files are stored there and are automatically updated by Taskter.
+
+## board.json
+
+Holds the Kanban board in JSON format. The file contains all tasks with their status, descriptions and assigned agent. It is rewritten whenever you add, edit or complete tasks from the CLI or TUI.
+
+## agents.json
+
+Stores the list of agents. Each agent entry records the system prompt, available tools, model and optional schedule. The file is created on demand and modified by the various `agent` subcommands.
+
+## okrs.json
+
+Contains your objectives and key results. Commands under `taskter okrs` load and save this file.
+
+## logs.log
+
+Plain text log with timestamps. New lines are appended when you run `logs add` or when agents execute tasks.
+
+## description.md
+
+Markdown file describing the project. `taskter init` creates a placeholder that you can edit manually or through the TUI.
+
+## email_config.json
+
+Optional email credentials used by the `send_email` tool. Place it in the directory if agents need to send messages. The exact keys are documented in the [Configuration](configuration.html) chapter.


### PR DESCRIPTION
## Summary
- document board data files in new docs chapter
- include chapter in book summary
- cross-link README to the new docs for initialization and config details

## Testing
- `./scripts/precommit.sh`

------
https://chatgpt.com/codex/tasks/task_e_68897f90f0808320a58a67ee7cbc49a4