### PR TITLE
Allow partial agent updates

### DIFF
--- a/docs/src/agent_system.md
+++ b/docs/src/agent_system.md
@@ -61,13 +61,15 @@ In the interactive board (`taskter board`), tasks assigned to an agent will be m
 
 ## Updating an Agent
 
-Use the `agent update` command to modify an existing agent's configuration:
+Use the `agent update` command to modify an existing agent's configuration. You
+can provide any combination of `--prompt`, `--tools` and `--model` to update
+only those fields:
 
 ```bash
-taskter agent update --id 1 --prompt "New prompt" --tools "taskter_task" --model "gemini-pro"
+taskter agent update --id 1 --model "gemini-pro"
 ```
 
-All three options are required and the previous configuration is overwritten.
+The previous configuration is preserved for any options that are not supplied.
 
 ## Creating Custom Tools
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -379,15 +379,21 @@ pub fn delete_agent(id: usize) -> anyhow::Result<()> {
 /// Returns an error if the agent list cannot be loaded or saved.
 pub fn update_agent(
     id: usize,
-    prompt: String,
-    tools: Vec<FunctionDeclaration>,
-    model: String,
+    prompt: Option<String>,
+    tools: Option<Vec<FunctionDeclaration>>,
+    model: Option<String>,
 ) -> anyhow::Result<()> {
     let mut agents = load_agents()?;
     if let Some(agent) = agents.iter_mut().find(|a| a.id == id) {
-        agent.system_prompt = prompt;
-        agent.tools = tools;
-        agent.model = model;
+        if let Some(p) = prompt {
+            agent.system_prompt = p;
+        }
+        if let Some(t) = tools {
+            agent.tools = t;
+        }
+        if let Some(m) = model {
+            agent.model = m;
+        }
         save_agents(&agents)?;
     }
     Ok(())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -115,20 +115,20 @@ pub enum AgentCommands {
         #[arg(long)]
         id: usize,
     },
-    /// Updates an agent's prompt and tools
+    /// Updates an agent's configuration
     Update {
         /// The id of the agent to update
         #[arg(long)]
         id: usize,
         /// The new system prompt for the agent
         #[arg(short, long)]
-        prompt: String,
+        prompt: Option<String>,
         /// The new tools the agent can use
         #[arg(short, long, num_args = 1..)]
-        tools: Vec<String>,
+        tools: Option<Vec<String>>,
         /// The new model for the agent
         #[arg(short, long)]
-        model: String,
+        model: Option<String>,
     },
     /// Schedule operations for an agent
     Schedule {

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -68,7 +68,11 @@ pub async fn handle(action: &AgentCommands) -> anyhow::Result<()> {
             tools,
             model,
         } => {
-            let function_declarations = parse_tool_specs(tools)?;
+            let function_declarations = if let Some(specs) = tools {
+                Some(parse_tool_specs(specs)?)
+            } else {
+                None
+            };
             agent_model::update_agent(*id, prompt.clone(), function_declarations, model.clone())?;
             println!("Agent {id} updated.");
         }

--- a/src/commands/task.rs
+++ b/src/commands/task.rs
@@ -1,6 +1,17 @@
 use crate::cli::TaskCommands;
 use crate::{agent, store};
 
+fn print_task(task: &store::Task) {
+    match &task.description {
+        Some(desc) if !desc.is_empty() => {
+            println!("  [{}] {} - {}", task.id, task.title, desc);
+        }
+        _ => {
+            println!("  [{}] {}", task.id, task.title);
+        }
+    }
+}
+
 pub async fn handle(action: &TaskCommands) -> anyhow::Result<()> {
     match action {
         TaskCommands::Add { title, description } => {
@@ -28,17 +39,6 @@ pub async fn handle(action: &TaskCommands) -> anyhow::Result<()> {
                     store::TaskStatus::ToDo => todo.push(task),
                     store::TaskStatus::InProgress => in_progress.push(task),
                     store::TaskStatus::Done => done.push(task),
-                }
-            }
-
-            fn print_task(task: &store::Task) {
-                match &task.description {
-                    Some(desc) if !desc.is_empty() => {
-                        println!("  [{}] {} - {}", task.id, task.title, desc);
-                    }
-                    _ => {
-                        println!("  [{}] {}", task.id, task.title);
-                    }
                 }
             }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -145,8 +145,12 @@ impl App {
                 .iter_mut()
                 .find(|t| t.id == task_id)
             {
-                let current_status_index = task.status.clone() as usize;
-                let next_status_index = (current_status_index as i8 + direction + 3) % 3;
+                let current_status_index: i8 = match task.status {
+                    TaskStatus::ToDo => 0,
+                    TaskStatus::InProgress => 1,
+                    TaskStatus::Done => 2,
+                };
+                let next_status_index = (current_status_index + direction + 3) % 3;
                 task.status = match next_status_index {
                     0 => TaskStatus::ToDo,
                     1 => TaskStatus::InProgress,

--- a/tests/cli_commands.rs
+++ b/tests/cli_commands.rs
@@ -259,21 +259,10 @@ fn update_agent_changes_configuration() {
             .assert()
             .success();
 
-        // update the agent
+        // update only the model of the agent
         Command::cargo_bin("taskter")
             .unwrap()
-            .args([
-                "agent",
-                "update",
-                "--id",
-                "1",
-                "--prompt",
-                "new helper",
-                "--tools",
-                "taskter_task",
-                "--model",
-                "gemini-2.5-flash",
-            ])
+            .args(["agent", "update", "--id", "1", "--model", "gemini-2.5-pro"])
             .assert()
             .success()
             .stdout(predicate::str::contains("Agent 1 updated."));
@@ -281,9 +270,9 @@ fn update_agent_changes_configuration() {
         let agents: Vec<Value> =
             serde_json::from_str(&fs::read_to_string(taskter::config::AGENTS_FILE).unwrap())
                 .unwrap();
-        assert_eq!(agents[0]["system_prompt"], "new helper");
-        assert_eq!(agents[0]["tools"][0]["name"], "taskter_task");
-        assert_eq!(agents[0]["model"], "gemini-2.5-flash");
+        assert_eq!(agents[0]["system_prompt"], "helper");
+        assert_eq!(agents[0]["tools"][0]["name"], "send_email");
+        assert_eq!(agents[0]["model"], "gemini-2.5-pro");
     });
 }
 

--- a/tools/taskter_agent.json
+++ b/tools/taskter_agent.json
@@ -1,6 +1,6 @@
 {
   "name": "taskter_agent",
-  "description": "Run the `taskter agent` command. Supported subcommands:\n- `add` --prompt <PROMPT> --tools <TOOLS>... --model <MODEL>\n- `list`\n- `remove` --id <ID>\n- `update` --id <ID> --prompt <PROMPT> [--tools <TOOLS>...]\nExamples:\n`{\"args\": [\"list\"]}` lists agents.\n`{\"args\": [\"add\", \"--prompt\", \"helper\", \"--tools\", \"run_bash\", \"--model\", \"gemini-pro\"]}` adds an agent.",
+  "description": "Run the `taskter agent` command. Supported subcommands:\n- `add` --prompt <PROMPT> --tools <TOOLS>... --model <MODEL>\n- `list`\n- `remove` --id <ID>\n- `update` --id <ID> [--prompt <PROMPT>] [--tools <TOOLS>...] [--model <MODEL>]\nExamples:\n`{\"args\": [\"list\"]}` lists agents.\n`{\"args\": [\"add\", \"--prompt\", \"helper\", \"--tools\", \"run_bash\", \"--model\", \"gemini-pro\"]}` adds an agent.",
   "parameters": {
     "type": "object",
     "properties": {


### PR DESCRIPTION
## Summary
- Allow `agent update` to modify only specified fields
- Update documentation and tests for optional agent update arguments

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688e5c8111fc83208876c3bff3a01fa5