### PR TITLE
Mark important results as must_use

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -12,7 +12,7 @@ use std::io::Write;
 use crate::config;
 
 /// Result of running an [`Agent`] on a [`Task`].
-#[must_use]
+#[must_use = "inspect the result to handle success or failure"]
 #[derive(Debug, PartialEq)]
 pub enum ExecutionResult {
     Success { comment: String },
@@ -294,7 +294,7 @@ pub async fn execute_task(agent: &Agent, task: Option<&Task>) -> Result<Executio
 }
 
 /// Describes an available tool for the language model.
-#[must_use]
+#[must_use = "register the declaration so the tool can be used"]
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct FunctionDeclaration {
     pub name: String,

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -12,6 +12,7 @@ use std::io::Write;
 use crate::config;
 
 /// Result of running an [`Agent`] on a [`Task`].
+#[must_use]
 #[derive(Debug, PartialEq)]
 pub enum ExecutionResult {
     Success { comment: String },
@@ -35,6 +36,7 @@ fn append_log(message: &str) -> anyhow::Result<()> {
 /// # Errors
 ///
 /// Returns an error if writing to the log fails or if a tool execution fails.
+#[must_use = "use the result to determine task outcome"]
 pub async fn execute_task(agent: &Agent, task: Option<&Task>) -> Result<ExecutionResult> {
     let client = Client::new();
     let log_message = if let Some(task) = task {
@@ -292,6 +294,7 @@ pub async fn execute_task(agent: &Agent, task: Option<&Task>) -> Result<Executio
 }
 
 /// Describes an available tool for the language model.
+#[must_use]
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct FunctionDeclaration {
     pub name: String,

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,30 +10,37 @@ pub const AGENTS_FILE: &str = ".taskter/agents.json";
 pub const DESCRIPTION_FILE: &str = ".taskter/description.md";
 pub const EMAIL_CONFIG_FILE: &str = ".taskter/email_config.json";
 
+#[must_use]
 pub fn dir() -> &'static Path {
     Path::new(DIR)
 }
 
+#[must_use]
 pub fn board_path() -> &'static Path {
     Path::new(BOARD_FILE)
 }
 
+#[must_use]
 pub fn okrs_path() -> &'static Path {
     Path::new(OKRS_FILE)
 }
 
+#[must_use]
 pub fn log_path() -> &'static Path {
     Path::new(LOG_FILE)
 }
 
+#[must_use]
 pub fn agents_path() -> &'static Path {
     Path::new(AGENTS_FILE)
 }
 
+#[must_use]
 pub fn description_path() -> &'static Path {
     Path::new(DESCRIPTION_FILE)
 }
 
+#[must_use]
 pub fn email_config_path() -> &'static Path {
     Path::new(EMAIL_CONFIG_FILE)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,37 +10,37 @@ pub const AGENTS_FILE: &str = ".taskter/agents.json";
 pub const DESCRIPTION_FILE: &str = ".taskter/description.md";
 pub const EMAIL_CONFIG_FILE: &str = ".taskter/email_config.json";
 
-#[must_use]
+#[must_use = "use the path to access Taskter data"]
 pub fn dir() -> &'static Path {
     Path::new(DIR)
 }
 
-#[must_use]
+#[must_use = "use the path to access Taskter data"]
 pub fn board_path() -> &'static Path {
     Path::new(BOARD_FILE)
 }
 
-#[must_use]
+#[must_use = "use the path to access Taskter data"]
 pub fn okrs_path() -> &'static Path {
     Path::new(OKRS_FILE)
 }
 
-#[must_use]
+#[must_use = "use the path to access Taskter data"]
 pub fn log_path() -> &'static Path {
     Path::new(LOG_FILE)
 }
 
-#[must_use]
+#[must_use = "use the path to access Taskter data"]
 pub fn agents_path() -> &'static Path {
     Path::new(AGENTS_FILE)
 }
 
-#[must_use]
+#[must_use = "use the path to access Taskter data"]
 pub fn description_path() -> &'static Path {
     Path::new(DESCRIPTION_FILE)
 }
 
-#[must_use]
+#[must_use = "use the path to access Taskter data"]
 pub fn email_config_path() -> &'static Path {
     Path::new(EMAIL_CONFIG_FILE)
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -39,6 +39,7 @@ pub static BUILTIN_TOOLS: Lazy<HashMap<&'static str, Tool>> = Lazy::new(|| {
 });
 
 /// Returns the names of all built-in tools.
+#[must_use]
 pub fn builtin_names() -> Vec<&'static str> {
     let mut names: Vec<&'static str> = BUILTIN_TOOLS.keys().copied().collect();
     names.sort();

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -39,7 +39,7 @@ pub static BUILTIN_TOOLS: Lazy<HashMap<&'static str, Tool>> = Lazy::new(|| {
 });
 
 /// Returns the names of all built-in tools.
-#[must_use]
+#[must_use = "check the list to know which tools are available"]
 pub fn builtin_names() -> Vec<&'static str> {
     let mut names: Vec<&'static str> = BUILTIN_TOOLS.keys().copied().collect();
     names.sort();


### PR DESCRIPTION
## Summary
- ensure `ExecutionResult` and `FunctionDeclaration` can't be silently dropped
- mark `execute_task` and config path helpers as `#[must_use]`
- flag built-in tool list retrieval with `#[must_use]`

## Testing
- `cargo clippy`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688e5c06badc8320b44867be4e258cba