### PR TITLE
Track agent runtime state

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -7,6 +7,7 @@
 
 //! Executes tasks using an agent and records progress in the log.
 
+use crate::status::StatusGuard;
 use crate::store::Task;
 use crate::tools;
 use anyhow::Result;
@@ -47,6 +48,7 @@ fn append_log(message: &str) -> anyhow::Result<()> {
 /// Returns an error if writing to the log fails or if a tool execution fails.
 #[must_use = "use the result to determine task outcome"]
 pub async fn execute_task(agent: &Agent, task: Option<&Task>) -> Result<ExecutionResult> {
+    let _status_guard = StatusGuard::new(agent.id);
     let client = Client::new();
     let log_message = if let Some(task) = task {
         format!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@ pub const LOG_FILE: &str = ".taskter/logs.log";
 pub const AGENTS_FILE: &str = ".taskter/agents.json";
 pub const DESCRIPTION_FILE: &str = ".taskter/description.md";
 pub const EMAIL_CONFIG_FILE: &str = ".taskter/email_config.json";
+pub const AGENT_STATUS_FILE: &str = ".taskter/agent_status.json";
 
 #[must_use = "use the path to access Taskter data"]
 pub fn dir() -> &'static Path {
@@ -44,4 +45,9 @@ pub fn description_path() -> &'static Path {
 #[must_use = "use the path to access Taskter data"]
 pub fn email_config_path() -> &'static Path {
     Path::new(EMAIL_CONFIG_FILE)
+}
+
+#[must_use = "use the path to access Taskter data"]
+pub fn agent_status_path() -> &'static Path {
+    Path::new(AGENT_STATUS_FILE)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod cli;
 pub mod commands;
 pub mod config;
 pub mod scheduler;
+pub mod status;
 pub mod store;
 pub mod tools;
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,5 +1,6 @@
 //! Cron-based scheduler that runs agents on a timetable.
 
+use crate::status::{set_status, AgentState};
 use crate::{agent, store};
 use agent::ExecutionResult;
 use chrono_tz::America::New_York;
@@ -34,8 +35,11 @@ pub async fn run() -> anyhow::Result<()> {
                             .collect();
 
                         if tasks.is_empty() {
+                            let _ = set_status(a.id, AgentState::Running);
                             let _ = agent::execute_task(&a, None).await;
+                            let _ = set_status(a.id, AgentState::Idle);
                         } else {
+                            let _ = set_status(a.id, AgentState::Running);
                             let task_data: Vec<(usize, store::Task)> = tasks
                                 .iter()
                                 .filter_map(|id| {
@@ -74,6 +78,7 @@ pub async fn run() -> anyhow::Result<()> {
                                     }
                                 }
                             }
+                            let _ = set_status(a.id, AgentState::Idle);
                         }
                         let _ = store::save_board(&board);
                     }

--- a/src/status.rs
+++ b/src/status.rs
@@ -19,7 +19,7 @@ pub fn load_status() -> Result<HashMap<usize, AgentState>> {
         fs::write(path, "{}")?;
     }
     let content = fs::read_to_string(path)?;
-    let map: HashMap<usize, AgentState> = serde_json::from_str(&content)?;
+    let map: HashMap<usize, AgentState> = serde_json::from_str(&content).unwrap_or_default();
     Ok(map)
 }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,0 +1,55 @@
+use std::collections::HashMap;
+use std::fs;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::config;
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AgentState {
+    Running,
+    Idle,
+}
+
+pub fn load_status() -> Result<HashMap<usize, AgentState>> {
+    let path = config::agent_status_path();
+    if !path.exists() {
+        fs::create_dir_all(path.parent().unwrap())?;
+        fs::write(path, "{}")?;
+    }
+    let content = fs::read_to_string(path)?;
+    let map: HashMap<usize, AgentState> = serde_json::from_str(&content)?;
+    Ok(map)
+}
+
+pub fn save_status(status: &HashMap<usize, AgentState>) -> Result<()> {
+    let path = config::agent_status_path();
+    let content = serde_json::to_string_pretty(status)?;
+    fs::write(path, content)?;
+    Ok(())
+}
+
+pub fn set_status(agent_id: usize, state: AgentState) -> Result<()> {
+    let mut statuses = load_status()?;
+    statuses.insert(agent_id, state);
+    save_status(&statuses)
+}
+
+pub struct StatusGuard {
+    agent_id: usize,
+}
+
+impl StatusGuard {
+    #[must_use]
+    pub fn new(agent_id: usize) -> Self {
+        let _ = set_status(agent_id, AgentState::Running);
+        Self { agent_id }
+    }
+}
+
+impl Drop for StatusGuard {
+    fn drop(&mut self) {
+        let _ = set_status(self.agent_id, AgentState::Idle);
+    }
+}

--- a/src/tui/handlers.rs
+++ b/src/tui/handlers.rs
@@ -1,6 +1,7 @@
 use super::app::{App, View};
 use super::render::ui;
 use crate::agent::{self};
+use crate::status::{set_status, AgentState};
 use crate::store::{self, Task, TaskStatus};
 use crossterm::{
     event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
@@ -224,6 +225,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                                         let agent_clone = agent.clone();
                                         let task_clone = task.clone();
                                         let board_clone = Arc::clone(&app.board);
+                                        let _ = set_status(agent.id, AgentState::Running);
                                         tokio::spawn(async move {
                                             let result = agent::execute_task(
                                                 &agent_clone,
@@ -261,6 +263,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                                                     }
                                                 }
                                             }
+                                            let _ = set_status(agent_clone.id, AgentState::Idle);
                                             store::save_board(&board).unwrap();
                                         });
                                     }


### PR DESCRIPTION
## Summary
- Add status module to persist agent states to `.taskter/agent_status.json`.
- Wrap `execute_task` with `StatusGuard` to mark agents running and idle automatically.
- Update scheduler and TUI to set agent status when spawning and completing tasks.

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68900550d60c832081ed1d5cb58f20b0