### PR TITLE
chore: uniquely name release binaries per OS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,14 @@ jobs:
           override: true
       - name: Build
         run: cargo build --release
+      - name: Rename binary
+        run: mv ${{ matrix.binary_path }} target/release/${{ matrix.artifact_name }}
+        shell: bash
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}
-          path: ${{ matrix.binary_path }}
+          path: target/release/${{ matrix.artifact_name }}
           if-no-files-found: error
 
   release:
@@ -50,4 +53,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: artifacts/**
+          files: |
+            artifacts/taskter-linux/taskter-linux
+            artifacts/taskter-windows.exe/taskter-windows.exe
+            artifacts/taskter-macos/taskter-macos


### PR DESCRIPTION
## Summary
- rename built binaries with OS-specific suffixes in release workflow
- upload artifacts and release assets with unique file names

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689006c4cdb883209142b49664f01828