### PR TITLE
Allow partial agent updates

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -391,15 +391,21 @@ pub fn delete_agent(id: usize) -> anyhow::Result<()> {
 /// Returns an error if the agent list cannot be loaded or saved.
 pub fn update_agent(
     id: usize,
-    prompt: String,
-    tools: Vec<FunctionDeclaration>,
-    model: String,
+    prompt: Option<String>,
+    tools: Option<Vec<FunctionDeclaration>>,
+    model: Option<String>,
 ) -> anyhow::Result<()> {
     let mut agents = load_agents()?;
     if let Some(agent) = agents.iter_mut().find(|a| a.id == id) {
-        agent.system_prompt = prompt;
-        agent.tools = tools;
-        agent.model = model;
+        if let Some(p) = prompt {
+            agent.system_prompt = p;
+        }
+        if let Some(t) = tools {
+            agent.tools = t;
+        }
+        if let Some(m) = model {
+            agent.model = m;
+        }
         save_agents(&agents)?;
     }
     Ok(())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -117,20 +117,20 @@ pub enum AgentCommands {
         #[arg(long)]
         id: usize,
     },
-    /// Updates an agent's prompt and tools
+    /// Updates an agent's configuration. Each field is optional.
     Update {
         /// The id of the agent to update
         #[arg(long)]
         id: usize,
         /// The new system prompt for the agent
         #[arg(short, long)]
-        prompt: String,
+        prompt: Option<String>,
         /// The new tools the agent can use
         #[arg(short, long, num_args = 1..)]
-        tools: Vec<String>,
+        tools: Option<Vec<String>>,
         /// The new model for the agent
         #[arg(short, long)]
-        model: String,
+        model: Option<String>,
     },
     /// Schedule operations for an agent
     Schedule {

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -70,7 +70,11 @@ pub async fn handle(action: &AgentCommands) -> anyhow::Result<()> {
             tools,
             model,
         } => {
-            let function_declarations = parse_tool_specs(tools)?;
+            let function_declarations = if let Some(specs) = tools {
+                Some(parse_tool_specs(specs)?)
+            } else {
+                None
+            };
             agent_model::update_agent(*id, prompt.clone(), function_declarations, model.clone())?;
             println!("Agent {id} updated.");
         }

--- a/tests/cli_commands.rs
+++ b/tests/cli_commands.rs
@@ -259,7 +259,7 @@ fn update_agent_changes_configuration() {
             .assert()
             .success();
 
-        // update the agent
+        // update the agent's tools and model only
         Command::cargo_bin("taskter")
             .unwrap()
             .args([
@@ -267,13 +267,26 @@ fn update_agent_changes_configuration() {
                 "update",
                 "--id",
                 "1",
-                "--prompt",
-                "new helper",
                 "--tools",
                 "taskter_task",
                 "--model",
-                "gemini-2.5-flash",
+                "gemini-2.5-pro",
             ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Agent 1 updated."));
+
+        let agents: Vec<Value> =
+            serde_json::from_str(&fs::read_to_string(taskter::config::AGENTS_FILE).unwrap())
+                .unwrap();
+        assert_eq!(agents[0]["system_prompt"], "helper");
+        assert_eq!(agents[0]["tools"][0]["name"], "taskter_task");
+        assert_eq!(agents[0]["model"], "gemini-2.5-pro");
+
+        // update the agent's prompt only
+        Command::cargo_bin("taskter")
+            .unwrap()
+            .args(["agent", "update", "--id", "1", "--prompt", "new helper"])
             .assert()
             .success()
             .stdout(predicate::str::contains("Agent 1 updated."));
@@ -283,7 +296,7 @@ fn update_agent_changes_configuration() {
                 .unwrap();
         assert_eq!(agents[0]["system_prompt"], "new helper");
         assert_eq!(agents[0]["tools"][0]["name"], "taskter_task");
-        assert_eq!(agents[0]["model"], "gemini-2.5-flash");
+        assert_eq!(agents[0]["model"], "gemini-2.5-pro");
     });
 }
 


### PR DESCRIPTION
## Summary
- allow updating only the specified agent fields (prompt, tools, model)
- test optional update behavior

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6890043a87c88320a304b5079d434cd3