### PR TITLE
fix(agent): surface tool failures and stable ids

### DIFF
--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -39,8 +39,14 @@ pub async fn handle(action: &AgentCommands) -> anyhow::Result<()> {
             } else {
                 None
             };
+            let next_id = agents
+                .iter()
+                .map(|a| a.id)
+                .max()
+                .unwrap_or(0)
+                .saturating_add(1);
             let new_agent = agent_model::Agent {
-                id: agents.len() + 1,
+                id: next_id,
                 system_prompt: prompt.clone(),
                 tools: function_declarations,
                 model: model.clone(),

--- a/src/commands/okrs.rs
+++ b/src/commands/okrs.rs
@@ -1,5 +1,3 @@
-use std::fs;
-
 use crate::cli::OkrCommands;
 use crate::store;
 
@@ -25,8 +23,8 @@ pub fn handle(action: &OkrCommands) -> anyhow::Result<()> {
             println!("OKR added successfully.");
         }
         OkrCommands::List => {
-            let okrs = fs::read_to_string(crate::config::okrs_path())?;
-            println!("{okrs}");
+            let okrs = store::load_okrs()?;
+            println!("{}", serde_json::to_string_pretty(&okrs)?);
         }
     }
     Ok(())

--- a/src/tools/email.rs
+++ b/src/tools/email.rs
@@ -37,12 +37,9 @@ pub fn execute(args: &Value) -> Result<String> {
     let body = args["body"]
         .as_str()
         .ok_or_else(|| anyhow!("body missing"))?;
-    match send_email(to, subject, body) {
-        Ok(_) => Ok(format!(
-            "Email sent to {to} with subject '{subject}' and body '{body}'"
-        )),
-        Err(e) => Ok(format!("Failed to send email: {e}")),
-    }
+    send_email(to, subject, body)
+        .map(|_| format!("Email sent to {to} with subject '{subject}' and body '{body}'"))
+        .map_err(|e| anyhow!("Failed to send email: {e}"))
 }
 
 /// Low level helper that sends an email using the configured SMTP server.

--- a/tests/tool_functions.rs
+++ b/tests/tool_functions.rs
@@ -199,6 +199,18 @@ fn send_email_requires_arguments() {
 }
 
 #[test]
+fn send_email_reports_missing_configuration() {
+    with_temp_dir(|| {
+        let err = taskter::tools::execute_tool(
+            "send_email",
+            &json!({"to": "user@example.com", "subject": "hi", "body": "hello"}),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("Email configuration not found"));
+    });
+}
+
+#[test]
 fn unknown_tool_returns_error() {
     with_temp_dir(|| {
         let err = taskter::tools::execute_tool("no_such_tool", &json!({})).unwrap_err();


### PR DESCRIPTION
Return an execution failure when tools error, keep agent ids monotonic, pretty-print OKRs, and extend CLI/tests for email config coverage.